### PR TITLE
Add player listing API and admin autocomplete

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -25,42 +25,42 @@ label{display:block;margin-top:10px;}
 <hr>
 <div>
 <h2>Touro Mecanico</h2>
-<label>Jogador <input id="bullPlayer"/></label>
+<label>Jogador <input id="bullPlayer" list="players"/></label>
 <label>Tempo <input id="bullTime" type="number"/></label>
 <button onclick="addBull()">Registrar</button>
 </div>
 <hr>
 <div>
 <h2>Guerra de Cotonete</h2>
-<label>P1 <input id="cottonP1"/></label>
-<label>P2 <input id="cottonP2"/></label>
-<label>Vencedor <input id="cottonWin"/></label>
+<label>P1 <input id="cottonP1" list="players"/></label>
+<label>P2 <input id="cottonP2" list="players"/></label>
+<label>Vencedor <input id="cottonWin" list="players"/></label>
 <button onclick="addCotton()">Registrar</button>
 </div>
 <hr>
 <div>
 <h2>Beer Pong</h2>
-<label>Time1 Jogador1 <input id="beerT1P1"/></label>
-<label>Time1 Jogador2 <input id="beerT1P2"/></label>
-<label>Time2 Jogador1 <input id="beerT2P1"/></label>
-<label>Time2 Jogador2 <input id="beerT2P2"/></label>
-<label>Vencedor <input id="beerWin"/></label>
+<label>Time1 Jogador1 <input id="beerT1P1" list="players"/></label>
+<label>Time1 Jogador2 <input id="beerT1P2" list="players"/></label>
+<label>Time2 Jogador1 <input id="beerT2P1" list="players"/></label>
+<label>Time2 Jogador2 <input id="beerT2P2" list="players"/></label>
+<label>Vencedor <input id="beerWin" list="players"/></label>
 <button onclick="addBeer()">Registrar</button>
 </div>
 <hr>
 <div>
 <h2>Pacal</h2>
-<label>P1 <input id="pacalP1"/></label>
-<label>P2 <input id="pacalP2"/></label>
-<label>Vencedor <input id="pacalWin"/></label>
+<label>P1 <input id="pacalP1" list="players"/></label>
+<label>P2 <input id="pacalP2" list="players"/></label>
+<label>Vencedor <input id="pacalWin" list="players"/></label>
 <button onclick="addPacal()">Registrar</button>
 </div>
 <hr>
 <div>
 <h2>Bingo</h2>
-<label>1º <input id="bingo1"/></label>
-<label>2º <input id="bingo2"/></label>
-<label>3º <input id="bingo3"/></label>
+<label>1º <input id="bingo1" list="players"/></label>
+<label>2º <input id="bingo2" list="players"/></label>
+<label>3º <input id="bingo3" list="players"/></label>
 <button onclick="addBingo()">Registrar</button>
 </div>
 <hr>
@@ -72,17 +72,24 @@ label{display:block;margin-top:10px;}
 </div>
 <hr>
 <button onclick="resetAll()">Zerar Tudo</button>
+<datalist id="players"></datalist>
 <script>
-function post(url,data){fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});} 
+function post(url,data){fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});}
+let players = {};
+function loadPlayers(){fetch('/api/players').then(r=>r.json()).then(p=>{players=p;updateDatalist();});}
+function updateDatalist(){playersElem.innerHTML=Object.keys(players).map(n=>`<option value="${n}">`).join('');}
+function ensurePlayer(name){if(!name||players[name])return;const team=prompt(`Time para ${name}? (blue/yellow)`);if(team){post('/api/player',{name,team});players[name]=team;updateDatalist();}}
 function saveTeams(){post('/api/config/teamNames',{blue:teamBlue.value,yellow:teamYellow.value});}
-function addPlayer(){post('/api/player',{name:playerName.value,team:playerTeam.value});}
-function addBull(){post('/api/bull',{name:bullPlayer.value,time:bullTime.value});}
-function addCotton(){post('/api/cotton',{p1:cottonP1.value,p2:cottonP2.value,winner:cottonWin.value});}
-function addBeer(){post('/api/beer',{team1:[beerT1P1.value,beerT1P2.value],team2:[beerT2P1.value,beerT2P2.value],winner:beerWin.value});}
-function addPacal(){post('/api/pacal',{p1:pacalP1.value,p2:pacalP2.value,winner:pacalWin.value});}
-function addBingo(){post('/api/bingo',{first:bingo1.value,second:bingo2.value,third:bingo3.value});}
+function addPlayer(){post('/api/player',{name:playerName.value,team:playerTeam.value});players[playerName.value]=playerTeam.value;updateDatalist();}
+function addBull(){ensurePlayer(bullPlayer.value);post('/api/bull',{name:bullPlayer.value,time:bullTime.value});}
+function addCotton(){[cottonP1.value,cottonP2.value,cottonWin.value].forEach(ensurePlayer);post('/api/cotton',{p1:cottonP1.value,p2:cottonP2.value,winner:cottonWin.value});}
+function addBeer(){[beerT1P1.value,beerT1P2.value,beerT2P1.value,beerT2P2.value,beerWin.value].forEach(ensurePlayer);post('/api/beer',{team1:[beerT1P1.value,beerT1P2.value],team2:[beerT2P1.value,beerT2P2.value],winner:beerWin.value});}
+function addPacal(){[pacalP1.value,pacalP2.value,pacalWin.value].forEach(ensurePlayer);post('/api/pacal',{p1:pacalP1.value,p2:pacalP2.value,winner:pacalWin.value});}
+function addBingo(){[bingo1.value,bingo2.value,bingo3.value].forEach(ensurePlayer);post('/api/bingo',{first:bingo1.value,second:bingo2.value,third:bingo3.value});}
 function addAttraction(){post('/api/attraction',{time:attrTime.value,name:attrName.value});}
 function resetAll(){post('/api/reset',{});}
+const playersElem=document.getElementById('players');
+loadPlayers();
 </script>
 </body>
 </html>

--- a/src/server.js
+++ b/src/server.js
@@ -53,6 +53,10 @@ app.get('/api/state', (req,res)=>{
   res.json(data);
 });
 
+app.get('/api/players', (req,res)=>{
+  res.json(data.players);
+});
+
 app.post('/api/player', (req,res)=>{
   const {name, team} = req.body;
   if(!name || !team) return res.status(400).end();


### PR DESCRIPTION
## Summary
- expose registered players via `/api/players`
- switch admin player inputs to datalist with autocomplete
- auto-prompt for team when unknown players are used

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6848ddd561288331a8d25e24913db79a