### PR TITLE
Add player management page and admin menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,5 @@ The provided Dockerfile uses the official `node:20` image as its base. You can s
 docker run -p 3000:3000 arraia
 ```
 
-Then access `http://localhost:3000/` for slides and `http://localhost:3000/admin.html` for admin panel.
+Then access `http://localhost:3000/` for slides and `http://localhost:3000/admin.html` for the admin menu.
+The players list can be reached directly at `http://localhost:3000/players.html`.

--- a/public/admin.html
+++ b/public/admin.html
@@ -2,108 +2,22 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>Admin</title>
+<title>Admin Menu</title>
 <style>
-body{font-family:sans-serif;}
-label{display:block;margin-top:10px;}
+body{font-family:sans-serif;display:flex;flex-wrap:wrap;gap:20px;padding:20px;}
+.menu-item{display:flex;flex-direction:column;justify-content:center;align-items:center;border:1px solid #ccc;border-radius:8px;width:120px;height:120px;text-decoration:none;color:black;background:#f0f0f0;}
+.menu-item span.emoji{font-size:48px;}
+.menu-item span.label{margin-top:auto;padding-bottom:5px;font-size:14px;}
 </style>
 </head>
 <body>
-<h1>Admin</h1>
-<div>
-<label>Nome do time azul <input id="teamBlue"/></label>
-<label>Nome do time amarelo <input id="teamYellow"/></label>
-<button onclick="saveTeams()">Salvar</button>
-</div>
-<hr>
-<div>
-<h2>Cadastrar jogador</h2>
-<label>Nome <input id="playerName"/></label>
-<select id="playerTeam"><option value="blue">Azul</option><option value="yellow">Amarelo</option></select>
-<button onclick="addPlayer()">Adicionar</button>
-</div>
-<hr>
-<div>
-<h2>Touro Mecanico</h2>
-<label>Jogador <input id="bullPlayer" list="players"/></label>
-<label>Tempo <input id="bullTime" type="number"/></label>
-<button onclick="addBull()">Registrar</button>
-</div>
-<hr>
-<div>
-<h2>Guerra de Cotonete</h2>
-<label>P1 <input id="cottonP1" list="players"/></label>
-<label>P2 <input id="cottonP2" list="players"/></label>
-<label>Vencedor <input id="cottonWin" list="players"/></label>
-<button onclick="addCotton()">Registrar</button>
-</div>
-<hr>
-<div>
-<h2>Beer Pong</h2>
-<label>Time1 Jogador1 <input id="beerT1P1" list="players"/></label>
-<label>Time1 Jogador2 <input id="beerT1P2" list="players"/></label>
-<label>Time2 Jogador1 <input id="beerT2P1" list="players"/></label>
-<label>Time2 Jogador2 <input id="beerT2P2" list="players"/></label>
-<label>Vencedor <input id="beerWin" list="players"/></label>
-<button onclick="addBeer()">Registrar</button>
-</div>
-<hr>
-<div>
-<h2>Pacal</h2>
-<label>P1 <input id="pacalP1" list="players"/></label>
-<label>P2 <input id="pacalP2" list="players"/></label>
-<label>Vencedor <input id="pacalWin" list="players"/></label>
-<button onclick="addPacal()">Registrar</button>
-</div>
-<hr>
-<div>
-<h2>Bingo</h2>
-<label>1º <input id="bingo1" list="players"/></label>
-<label>2º <input id="bingo2" list="players"/></label>
-<label>3º <input id="bingo3" list="players"/></label>
-<button onclick="addBingo()">Registrar</button>
-</div>
-<hr>
-<div>
-<h2>Atração</h2>
-<label>Horario (YYYY-MM-DDTHH:MM:SS) <input id="attrTime"/></label>
-<label>Nome <input id="attrName"/></label>
-<button onclick="addAttraction()">Adicionar</button>
-</div>
-<hr>
-<button onclick="resetAll()">Zerar Tudo</button>
-<hr>
-<div>
-<h2>Placar</h2>
-<ul id="scoreBoard"></ul>
-</div>
-<datalist id="players"></datalist>
-<script>
-function post(url,data){fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});}
-let players = {};
-function loadPlayers(){fetch('/api/players').then(r=>r.json()).then(p=>{players=p;updateDatalist();});}
-function updateDatalist(){playersElem.innerHTML=Object.keys(players).map(n=>`<option value="${n}">`).join('');}
-function ensurePlayer(name){if(!name||players[name])return;const team=prompt(`Time para ${name}? (blue/yellow)`);if(team){post('/api/player',{name,team});players[name]=team;updateDatalist();}}
-function saveTeams(){post('/api/config/teamNames',{blue:teamBlue.value,yellow:teamYellow.value});}
-function addPlayer(){post('/api/player',{name:playerName.value,team:playerTeam.value});players[playerName.value]=playerTeam.value;updateDatalist();}
-function addBull(){ensurePlayer(bullPlayer.value);post('/api/bull',{name:bullPlayer.value,time:bullTime.value});}
-function addCotton(){[cottonP1.value,cottonP2.value,cottonWin.value].forEach(ensurePlayer);post('/api/cotton',{p1:cottonP1.value,p2:cottonP2.value,winner:cottonWin.value});}
-function addBeer(){[beerT1P1.value,beerT1P2.value,beerT2P1.value,beerT2P2.value,beerWin.value].forEach(ensurePlayer);post('/api/beer',{team1:[beerT1P1.value,beerT1P2.value],team2:[beerT2P1.value,beerT2P2.value],winner:beerWin.value});}
-function addPacal(){[pacalP1.value,pacalP2.value,pacalWin.value].forEach(ensurePlayer);post('/api/pacal',{p1:pacalP1.value,p2:pacalP2.value,winner:pacalWin.value});}
-function addBingo(){[bingo1.value,bingo2.value,bingo3.value].forEach(ensurePlayer);post('/api/bingo',{first:bingo1.value,second:bingo2.value,third:bingo3.value});}
-function addAttraction(){post('/api/attraction',{time:attrTime.value,name:attrName.value});}
-function resetAll(){post('/api/reset',{});}
-const playersElem=document.getElementById('players');
-loadPlayers();
-function loadScore(){
-  fetch('/api/state').then(r=>r.json()).then(s=>{
-    const ul=document.getElementById('scoreBoard');
-    const entries=Object.entries(s.scores).sort((a,b)=>b[1]-a[1]);
-    ul.innerHTML=entries.map(([team,score],i)=>`<li>${s.teamNames[team]} - ${score}${i===0?' 🏆':''}</li>`).join('');
-  });
-}
-loadScore();
-setInterval(loadScore,5000);
-</script>
+<a class="menu-item" href="players.html">
+  <span class="emoji">👥</span>
+  <span class="label">Jogadores</span>
+</a>
+<a class="menu-item" href="manage.html">
+  <span class="emoji">🛠️</span>
+  <span class="label">Painel Completo</span>
+</a>
 </body>
 </html>

--- a/public/manage.html
+++ b/public/manage.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Admin</title>
+<style>
+body{font-family:sans-serif;}
+label{display:block;margin-top:10px;}
+</style>
+</head>
+<body>
+<h1>Admin</h1>
+<div>
+<label>Nome do time azul <input id="teamBlue"/></label>
+<label>Nome do time amarelo <input id="teamYellow"/></label>
+<button onclick="saveTeams()">Salvar</button>
+</div>
+<hr>
+<div>
+<h2>Cadastrar jogador</h2>
+<label>Nome <input id="playerName"/></label>
+<select id="playerTeam"><option value="blue">Azul</option><option value="yellow">Amarelo</option></select>
+<button onclick="addPlayer()">Adicionar</button>
+</div>
+<hr>
+<div>
+<h2>Touro Mecanico</h2>
+<label>Jogador <input id="bullPlayer" list="players"/></label>
+<label>Tempo <input id="bullTime" type="number"/></label>
+<button onclick="addBull()">Registrar</button>
+</div>
+<hr>
+<div>
+<h2>Guerra de Cotonete</h2>
+<label>P1 <input id="cottonP1" list="players"/></label>
+<label>P2 <input id="cottonP2" list="players"/></label>
+<label>Vencedor <input id="cottonWin" list="players"/></label>
+<button onclick="addCotton()">Registrar</button>
+</div>
+<hr>
+<div>
+<h2>Beer Pong</h2>
+<label>Time1 Jogador1 <input id="beerT1P1" list="players"/></label>
+<label>Time1 Jogador2 <input id="beerT1P2" list="players"/></label>
+<label>Time2 Jogador1 <input id="beerT2P1" list="players"/></label>
+<label>Time2 Jogador2 <input id="beerT2P2" list="players"/></label>
+<label>Vencedor <input id="beerWin" list="players"/></label>
+<button onclick="addBeer()">Registrar</button>
+</div>
+<hr>
+<div>
+<h2>Pacal</h2>
+<label>P1 <input id="pacalP1" list="players"/></label>
+<label>P2 <input id="pacalP2" list="players"/></label>
+<label>Vencedor <input id="pacalWin" list="players"/></label>
+<button onclick="addPacal()">Registrar</button>
+</div>
+<hr>
+<div>
+<h2>Bingo</h2>
+<label>1º <input id="bingo1" list="players"/></label>
+<label>2º <input id="bingo2" list="players"/></label>
+<label>3º <input id="bingo3" list="players"/></label>
+<button onclick="addBingo()">Registrar</button>
+</div>
+<hr>
+<div>
+<h2>Atração</h2>
+<label>Horario (YYYY-MM-DDTHH:MM:SS) <input id="attrTime"/></label>
+<label>Nome <input id="attrName"/></label>
+<button onclick="addAttraction()">Adicionar</button>
+</div>
+<hr>
+<button onclick="resetAll()">Zerar Tudo</button>
+<hr>
+<div>
+<h2>Placar</h2>
+<ul id="scoreBoard"></ul>
+</div>
+<datalist id="players"></datalist>
+<script>
+function post(url,data){fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});}
+let players = {};
+function loadPlayers(){fetch('/api/players').then(r=>r.json()).then(p=>{players=p;updateDatalist();});}
+function updateDatalist(){playersElem.innerHTML=Object.keys(players).map(n=>`<option value="${n}">`).join('');}
+function ensurePlayer(name){if(!name||players[name])return;const team=prompt(`Time para ${name}? (blue/yellow)`);if(team){post('/api/player',{name,team});players[name]=team;updateDatalist();}}
+function saveTeams(){post('/api/config/teamNames',{blue:teamBlue.value,yellow:teamYellow.value});}
+function addPlayer(){post('/api/player',{name:playerName.value,team:playerTeam.value});players[playerName.value]=playerTeam.value;updateDatalist();}
+function addBull(){ensurePlayer(bullPlayer.value);post('/api/bull',{name:bullPlayer.value,time:bullTime.value});}
+function addCotton(){[cottonP1.value,cottonP2.value,cottonWin.value].forEach(ensurePlayer);post('/api/cotton',{p1:cottonP1.value,p2:cottonP2.value,winner:cottonWin.value});}
+function addBeer(){[beerT1P1.value,beerT1P2.value,beerT2P1.value,beerT2P2.value,beerWin.value].forEach(ensurePlayer);post('/api/beer',{team1:[beerT1P1.value,beerT1P2.value],team2:[beerT2P1.value,beerT2P2.value],winner:beerWin.value});}
+function addPacal(){[pacalP1.value,pacalP2.value,pacalWin.value].forEach(ensurePlayer);post('/api/pacal',{p1:pacalP1.value,p2:pacalP2.value,winner:pacalWin.value});}
+function addBingo(){[bingo1.value,bingo2.value,bingo3.value].forEach(ensurePlayer);post('/api/bingo',{first:bingo1.value,second:bingo2.value,third:bingo3.value});}
+function addAttraction(){post('/api/attraction',{time:attrTime.value,name:attrName.value});}
+function resetAll(){post('/api/reset',{});}
+const playersElem=document.getElementById('players');
+loadPlayers();
+function loadScore(){
+  fetch('/api/state').then(r=>r.json()).then(s=>{
+    const ul=document.getElementById('scoreBoard');
+    const entries=Object.entries(s.scores).sort((a,b)=>b[1]-a[1]);
+    ul.innerHTML=entries.map(([team,score],i)=>`<li>${s.teamNames[team]} - ${score}${i===0?' 🏆':''}</li>`).join('');
+  });
+}
+loadScore();
+setInterval(loadScore,5000);
+</script>
+</body>
+</html>

--- a/public/players.html
+++ b/public/players.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Jogadores</title>
+<style>
+body{font-family:sans-serif;padding:20px;}
+table{border-collapse:collapse;width:100%;}
+th,td{border:1px solid #ccc;padding:5px;text-align:left;}
+button{margin-left:5px;}
+</style>
+</head>
+<body>
+<h1>Jogadores</h1>
+<table id="playersTable"></table>
+<h2>Adicionar Jogador</h2>
+<input id="newName" placeholder="Nome"/>
+<select id="newTeam"><option value="blue">Azul</option><option value="yellow">Amarelo</option></select>
+<button onclick="addPlayer()">Adicionar</button>
+<script>
+function fetchPlayers(){
+  fetch('/api/players').then(r=>r.json()).then(p=>{players=p;render();});
+}
+let players={};
+function render(){
+  const tbl=document.getElementById('playersTable');
+  tbl.innerHTML='<tr><th>Nome</th><th>Time</th><th>Ações</th></tr>'+
+    Object.entries(players).map(([name,team])=>{
+      return `<tr>
+        <td><input value="${name}" data-old="${name}" class="name"/></td>
+        <td>
+          <select class="team">
+            <option value="blue" ${team==='blue'?'selected':''}>Azul</option>
+            <option value="yellow" ${team==='yellow'?'selected':''}>Amarelo</option>
+          </select>
+        </td>
+        <td>
+          <button onclick="save(this)">Salvar</button>
+          <button onclick="removePlayer(this)">Excluir</button>
+        </td>
+      </tr>`;
+    }).join('');
+}
+function save(btn){
+  const tr=btn.closest('tr');
+  const oldName=tr.querySelector('.name').getAttribute('data-old');
+  const newName=tr.querySelector('.name').value;
+  const team=tr.querySelector('.team').value;
+  fetch('/api/player/'+encodeURIComponent(oldName),{
+    method:'PUT',
+    headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({name:newName,team})
+  }).then(fetchPlayers);
+}
+function removePlayer(btn){
+  const tr=btn.closest('tr');
+  const name=tr.querySelector('.name').getAttribute('data-old');
+  fetch('/api/player/'+encodeURIComponent(name),{method:'DELETE'}).then(fetchPlayers);
+}
+function addPlayer(){
+  const name=document.getElementById('newName').value;
+  const team=document.getElementById('newTeam').value;
+  fetch('/api/player',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name,team})}).then(()=>{document.getElementById('newName').value='';fetchPlayers();});
+}
+fetchPlayers();
+</script>
+</body>
+</html>

--- a/src/server.js
+++ b/src/server.js
@@ -64,6 +64,24 @@ app.post('/api/player', (req,res)=>{
   res.end();
 });
 
+app.put('/api/player/:name', (req,res)=>{
+  const oldName = req.params.name;
+  if(!data.players[oldName]) return res.status(404).end();
+  const {name = oldName, team} = req.body;
+  if(name !== oldName){
+    data.players[name] = data.players[oldName];
+    delete data.players[oldName];
+  }
+  if(team) data.players[name] = team;
+  res.end();
+});
+
+app.delete('/api/player/:name', (req,res)=>{
+  const name = req.params.name;
+  delete data.players[name];
+  res.end();
+});
+
 app.post('/api/bull', (req,res)=>{
   const {name,time} = req.body;
   data.bullTimes.push({name,time:parseFloat(time)});


### PR DESCRIPTION
## Summary
- create admin menu with emoji buttons
- add players page to edit team or name
- allow updating/deleting players via API
- document new players page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848e8be8c2c8331b6aadd3898b8d13c