### PR TITLE
Add points configuration page

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ The provided Dockerfile uses the official `node:20` image as its base. You can s
 docker run -p 3000:3000 arraia
 ```
 
-Then access `http://localhost:3000/` for slides and `http://localhost:3000/admin.html` for admin panel.
+Then access `http://localhost:3000/` for slides, `http://localhost:3000/admin.html` for the admin panel and `http://localhost:3000/pontos.html` to configure scoring.

--- a/public/index.html
+++ b/public/index.html
@@ -19,17 +19,19 @@ let state={};
 function render(){
   slidesEl.innerHTML='';
   const slides=[];
-  if(state.bullTimes.length>0){
-    const sorted=[...state.bullTimes].sort((a,b)=>a.time-b.time).slice(0,6);
-    let html='<h1>Top Touro</h1><ol>';let i=0;
-    sorted.forEach(r=>{
-      i++;
-      const points = i===1 ? state.points.bullFirst : i===2 ? state.points.bullSecond : 0;
-      html+=`<li><span class="team-${state.players[r.name]}">${r.name}</span> - ${r.time}s (${points} pts) ${i==1?'🏆':''}</li>`;
-    });
-    html+='</ol>';
-    slides.push({bg:'darkred',html});
-  }
+    if(state.bullTimes.length>0){
+      const keys=['bullFirst','bullSecond','bullThird','bullFourth','bullFifth'];
+      const sorted=[...state.bullTimes].sort((a,b)=>a.time-b.time).slice(0,keys.length);
+      let html='<h1>Top Touro</h1><ol>';let i=0;
+      sorted.forEach(r=>{
+        const k=keys[i];
+        const pts=state.points[k]||0;
+        html+=`<li><span class="team-${state.players[r.name]}">${r.name}</span> - ${r.time}s (${pts} pts) ${i==0?'🏆':''}</li>`;
+        i++;
+      });
+      html+='</ol>';
+      slides.push({bg:'darkred',html});
+    }
   if(state.cottonWars.length>0){
     let html='<h1>Guerra de Cotonete</h1><ul>';
     state.cottonWars.slice(-5).forEach(b=>{html+=`<li><span class="team-${state.players[b.p1]}">${b.p1}</span> vs <span class="team-${state.players[b.p2]}">${b.p2}</span> 🏆 <span class="team-${state.players[b.winner]}">${b.winner}</span></li>`});

--- a/public/pontos.html
+++ b/public/pontos.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+<meta charset="UTF-8">
+<title>Configurar Pontos</title>
+<style>
+body{font-family:sans-serif;}
+label{display:block;margin-top:10px;}
+</style>
+</head>
+<body>
+<h1>Editar Pontos</h1>
+<div>
+<label>1º lugar Touro <input id="bullFirst" type="number"></label>
+<label>2º lugar Touro <input id="bullSecond" type="number"></label>
+<label>3º lugar Touro <input id="bullThird" type="number"></label>
+<label>4º lugar Touro <input id="bullFourth" type="number"></label>
+<label>5º lugar Touro <input id="bullFifth" type="number"></label>
+<label>1º lugar Bingo <input id="bingoFirst" type="number"></label>
+<label>2º lugar Bingo <input id="bingoSecond" type="number"></label>
+<label>Vitória Beer Pong <input id="beerWin" type="number"></label>
+<label>Vitória Cotonete <input id="cottonWin" type="number"></label>
+<label>Vitória Pacal <input id="pacalWin" type="number"></label>
+<button onclick="savePoints()">Salvar</button>
+</div>
+<script>
+function loadPoints(){
+  fetch('/api/state').then(r=>r.json()).then(s=>{
+    const p=s.points;
+    bullFirst.value=p.bullFirst||0;
+    bullSecond.value=p.bullSecond||0;
+    bullThird.value=p.bullThird||0;
+    bullFourth.value=p.bullFourth||0;
+    bullFifth.value=p.bullFifth||0;
+    bingoFirst.value=p.bingoFirst||0;
+    bingoSecond.value=p.bingoSecond||0;
+    beerWin.value=p.beerWin||0;
+    cottonWin.value=p.cottonWin||0;
+    pacalWin.value=p.pacalWin||0;
+  });
+}
+function savePoints(){
+  const pts={
+    bullFirst:bullFirst.value,
+    bullSecond:bullSecond.value,
+    bullThird:bullThird.value,
+    bullFourth:bullFourth.value,
+    bullFifth:bullFifth.value,
+    bingoFirst:bingoFirst.value,
+    bingoSecond:bingoSecond.value,
+    beerWin:beerWin.value,
+    cottonWin:cottonWin.value,
+    pacalWin:pacalWin.value
+  };
+  fetch('/api/config/points',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(pts)});
+}
+loadPoints();
+</script>
+</body>
+</html>

--- a/src/server.js
+++ b/src/server.js
@@ -21,6 +21,9 @@ const data = {
   points: {
     bullFirst: 20,
     bullSecond: 10,
+    bullThird: 5,
+    bullFourth: 3,
+    bullFifth: 1,
     cottonWin: 3,
     beerWin: 3,
     pacalWin: 3,
@@ -33,10 +36,15 @@ const data = {
 
 function computeScores() {
   data.scores = {blue:0, yellow:0};
-  if (data.bullTimes.length >= 2) {
-    const sorted = [...data.bullTimes].sort((a,b)=>a.time-b.time).slice(0,2);
-    if(sorted[0]) data.scores[data.players[sorted[0].name]] += data.points.bullFirst;
-    if(sorted[1]) data.scores[data.players[sorted[1].name]] += data.points.bullSecond;
+  if (data.bullTimes.length > 0) {
+    const keys = ['bullFirst','bullSecond','bullThird','bullFourth','bullFifth'];
+    const sorted = [...data.bullTimes].sort((a,b)=>a.time-b.time).slice(0, keys.length);
+    sorted.forEach((r,i)=>{
+      const k = keys[i];
+      if(r && data.points[k]) {
+        data.scores[data.players[r.name]] += data.points[k];
+      }
+    });
   }
   data.cottonWars.forEach(b=>{ data.scores[data.players[b.winner]] += data.points.cottonWin; });
   data.beerPongs.forEach(b=>{ data.scores[data.players[b.winner]] += data.points.beerWin; });
@@ -102,6 +110,14 @@ app.post('/api/attraction', (req,res)=>{
 
 app.post('/api/config/teamNames', (req,res)=>{
   data.teamNames=req.body;
+  res.end();
+});
+
+app.post('/api/config/points', (req,res)=>{
+  Object.keys(req.body).forEach(k=>{
+    const v = parseFloat(req.body[k]);
+    if(!isNaN(v)) data.points[k]=v;
+  });
   res.end();
 });
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -14,4 +14,17 @@ describe('Express API', () => {
 
     expect(res.body.players.Alice).toBe('blue');
   });
+
+  it('updates points configuration', async () => {
+    await request(app)
+      .post('/api/config/points')
+      .send({ bullFirst: 99 })
+      .expect(200);
+
+    const res = await request(app)
+      .get('/api/state')
+      .expect(200);
+
+    expect(res.body.points.bullFirst).toBe(99);
+  });
 });


### PR DESCRIPTION
## Summary
- allow configuring scoring points through new `/api/config/points` route
- compute bull points for top five placements
- show bull points for five spots on slides
- add `pontos.html` for editing the points
- document new page in README
- test updating points

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848e93c90648331b62135f2a96e6b4b