### PR TITLE
Implement lineup management page

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This project provides a simple slide show and admin panel for a local party scor
   - Record results for each activity.
   - Configure attraction times and team names.
   - Reset all data when needed.
+  - Manage the attraction lineup through a simple editor.
 
 ## Usage
 
@@ -37,4 +38,4 @@ The provided Dockerfile uses the official `node:20` image as its base. You can s
 docker run -p 3000:3000 arraia
 ```
 
-Then access `http://localhost:3000/` for slides and `http://localhost:3000/admin.html` for admin panel.
+Then access `http://localhost:3000/` for slides, `http://localhost:3000/admin.html` for the admin panel and `http://localhost:3000/lineup.html` for the lineup editor.

--- a/public/lineup.html
+++ b/public/lineup.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+<meta charset="UTF-8">
+<title>Lineup</title>
+<style>
+body{font-family:sans-serif;padding:20px;}
+table{border-collapse:collapse;width:100%;}
+th,td{border:1px solid #ccc;padding:4px;text-align:left;}
+</style>
+</head>
+<body>
+<h1>Lineup</h1>
+<table id="lineupTable">
+<thead>
+<tr><th>Nome da atração</th><th>Horário de Início</th><th>Ações</th></tr>
+</thead>
+<tbody></tbody>
+</table>
+<h3>Adicionar nova atração</h3>
+<label>Nome <input id="newName"></label>
+<label>Horário (YYYY-MM-DDTHH:MM:SS) <input id="newTime"></label>
+<button id="addBtn">Adicionar</button>
+<script>
+async function load(){
+  const res = await fetch('/api/attractions');
+  const data = await res.json();
+  const tbody = document.querySelector('#lineupTable tbody');
+  tbody.innerHTML = '';
+  data.forEach((a,idx)=>{
+    const tr=document.createElement('tr');
+    tr.dataset.index=idx;
+    tr.innerHTML=`<td><input data-field="name" value="${a.name}" disabled></td>`+
+      `<td><input data-field="time" value="${a.time}" disabled></td>`+
+      `<td><button data-action="edit">Editar</button>`+
+      `<button data-action="save" style="display:none">Salvar</button>`+
+      `<button data-action="delete">Excluir</button></td>`;
+    tbody.appendChild(tr);
+  });
+}
+async function add(){
+  const name=document.getElementById('newName').value;
+  const time=document.getElementById('newTime').value;
+  await fetch('/api/attraction',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name,time})});
+  document.getElementById('newName').value='';
+  document.getElementById('newTime').value='';
+  load();
+}
+document.getElementById('addBtn').onclick=add;
+document.querySelector('#lineupTable tbody').addEventListener('click',async e=>{
+  const btn=e.target;
+  const tr=btn.closest('tr');
+  if(!tr) return;
+  const idx=tr.dataset.index;
+  if(btn.dataset.action==='edit'){
+    tr.querySelectorAll('input').forEach(i=>i.disabled=false);
+    tr.querySelector('[data-action=save]').style.display='';
+    tr.querySelector('[data-action=edit]').style.display='none';
+  }else if(btn.dataset.action==='save'){
+    const name=tr.querySelector('input[data-field=name]').value;
+    const time=tr.querySelector('input[data-field=time]').value;
+    await fetch('/api/attraction/'+idx,{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({name,time})});
+    tr.querySelectorAll('input').forEach(i=>i.disabled=true);
+    tr.querySelector('[data-action=save]').style.display='none';
+    tr.querySelector('[data-action=edit]').style.display='';
+  }else if(btn.dataset.action==='delete'){
+    await fetch('/api/attraction/'+idx,{method:'DELETE'});
+    load();
+  }
+});
+load();
+</script>
+</body>
+</html>

--- a/src/server.js
+++ b/src/server.js
@@ -100,6 +100,25 @@ app.post('/api/attraction', (req,res)=>{
   res.end();
 });
 
+app.get('/api/attractions', (req,res)=>{
+  res.json(data.attractions);
+});
+
+app.put('/api/attraction/:index', (req,res)=>{
+  const idx = parseInt(req.params.index,10);
+  if (Number.isNaN(idx) || !data.attractions[idx]) return res.status(404).end();
+  const { time, name } = req.body;
+  data.attractions[idx] = { time, name };
+  res.end();
+});
+
+app.delete('/api/attraction/:index', (req,res)=>{
+  const idx = parseInt(req.params.index,10);
+  if (Number.isNaN(idx) || !data.attractions[idx]) return res.status(404).end();
+  data.attractions.splice(idx,1);
+  res.end();
+});
+
 app.post('/api/config/teamNames', (req,res)=>{
   data.teamNames=req.body;
   res.end();

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -14,4 +14,32 @@ describe('Express API', () => {
 
     expect(res.body.players.Alice).toBe('blue');
   });
+
+  it('manages attractions', async () => {
+    await request(app)
+      .post('/api/attraction')
+      .send({ name: 'Show', time: '2023-01-01T10:00:00' })
+      .expect(200);
+
+    await request(app)
+      .put('/api/attraction/0')
+      .send({ name: 'Show 2', time: '2023-01-01T11:00:00' })
+      .expect(200);
+
+    const list = await request(app)
+      .get('/api/attractions')
+      .expect(200);
+
+    expect(list.body[0]).toEqual({ name: 'Show 2', time: '2023-01-01T11:00:00' });
+
+    await request(app)
+      .delete('/api/attraction/0')
+      .expect(200);
+
+    const empty = await request(app)
+      .get('/api/attractions')
+      .expect(200);
+
+    expect(empty.body).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary
- add CRUD API endpoints for attractions
- create lineup editor page
- document lineup page in README
- test lineup API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848e9d975388331880af426f742eb3b