### PR TITLE
Skip deleted players in score calculation

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -41,18 +41,31 @@ function computeScores() {
     const sorted = [...data.bullTimes].sort((a,b)=>a.time-b.time).slice(0, keys.length);
     sorted.forEach((r,i)=>{
       const k = keys[i];
-      if(r && data.points[k]) {
-        data.scores[data.players[r.name]] += data.points[k];
+      const team = data.players[r.name];
+      if(r && data.points[k] && team) {
+        data.scores[team] += data.points[k];
       }
     });
   }
-  data.cottonWars.forEach(b=>{ data.scores[data.players[b.winner]] += data.points.cottonWin; });
-  data.beerPongs.forEach(b=>{ data.scores[data.players[b.winner]] += data.points.beerWin; });
-  data.pacalWars.forEach(b=>{ data.scores[data.players[b.winner]] += data.points.pacalWin; });
+  data.cottonWars.forEach(b=>{
+    const team = data.players[b.winner];
+    if(team) data.scores[team] += data.points.cottonWin;
+  });
+  data.beerPongs.forEach(b=>{
+    const team = data.players[b.winner];
+    if(team) data.scores[team] += data.points.beerWin;
+  });
+  data.pacalWars.forEach(b=>{
+    const team = data.players[b.winner];
+    if(team) data.scores[team] += data.points.pacalWin;
+  });
   if(data.bingoWinners){
-    if(data.bingoWinners.first) data.scores[data.players[data.bingoWinners.first]] += data.points.bingoFirst;
-    if(data.bingoWinners.second) data.scores[data.players[data.bingoWinners.second]] += data.points.bingoSecond;
-    if(data.bingoWinners.third) data.scores[data.players[data.bingoWinners.third]] += data.points.bingoThird;
+    if(data.bingoWinners.first && data.players[data.bingoWinners.first])
+      data.scores[data.players[data.bingoWinners.first]] += data.points.bingoFirst;
+    if(data.bingoWinners.second && data.players[data.bingoWinners.second])
+      data.scores[data.players[data.bingoWinners.second]] += data.points.bingoSecond;
+    if(data.bingoWinners.third && data.players[data.bingoWinners.third])
+      data.scores[data.players[data.bingoWinners.third]] += data.points.bingoThird;
   }
 }
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -15,7 +15,6 @@ describe('Express API', () => {
     expect(res.body.players.Alice).toBe('blue');
   });
 
-codex/implementar-página-lineup
   it('manages attractions', async () => {
     await request(app)
       .post('/api/attraction')
@@ -42,6 +41,7 @@ codex/implementar-página-lineup
       .expect(200);
 
     expect(empty.body).toEqual([]);
+  });
 
   it('updates points configuration', async () => {
     await request(app)
@@ -54,6 +54,24 @@ codex/implementar-página-lineup
       .expect(200);
 
     expect(res.body.points.bullFirst).toBe(99);
-main
+  });
+
+  it('ignores scores for removed players', async () => {
+    await request(app).post('/api/player').send({ name: 'Alice', team: 'blue' }).expect(200);
+    await request(app).post('/api/player').send({ name: 'Bob', team: 'yellow' }).expect(200);
+
+    await request(app)
+      .post('/api/cotton')
+      .send({ p1: 'Alice', p2: 'Bob', winner: 'Alice' })
+      .expect(200);
+
+    await request(app).delete('/api/player/Alice').expect(200);
+
+    const res = await request(app).get('/api/state').expect(200);
+
+    expect(res.body.players.Alice).toBeUndefined();
+    expect(res.body.scores.blue).toBe(0);
+    expect(res.body.scores.yellow).toBe(0);
+    expect('undefined' in res.body.scores).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- ignore removed players in score computation
- clean up broken test file and add regression covering removed players

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848edfe81b883319e1520016b59be6b