### PR TITLE
Update websocket with initial state

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -171,6 +171,10 @@ function startServer() {
   });
 
   const wss = new WebSocket.Server({ server });
+  wss.on('connection', ws => {
+    computeScores();
+    ws.send(JSON.stringify(data));
+  });
   function broadcast() {
     computeScores();
     const msg = JSON.stringify(data);

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -15,7 +15,6 @@ describe('Express API', () => {
     expect(res.body.players.Alice).toBe('blue');
   });
 
-codex/implementar-página-lineup
   it('manages attractions', async () => {
     await request(app)
       .post('/api/attraction')
@@ -42,6 +41,7 @@ codex/implementar-página-lineup
       .expect(200);
 
     expect(empty.body).toEqual([]);
+  });
 
   it('updates points configuration', async () => {
     await request(app)
@@ -54,6 +54,5 @@ codex/implementar-página-lineup
       .expect(200);
 
     expect(res.body.points.bullFirst).toBe(99);
-main
   });
 });


### PR DESCRIPTION
## Summary
- send current state to newly connected websocket client
- fix broken jest tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848ee1dba7c83318c98f9acf54b81ed