### PR TITLE
Use datetime-local inputs for lineup

### DIFF
--- a/public/lineup.html
+++ b/public/lineup.html
@@ -19,7 +19,7 @@ th,td{border:1px solid #ccc;padding:4px;text-align:left;}
 </table>
 <h3>Adicionar nova atração</h3>
 <label>Nome <input id="newName"></label>
-<label>Horário (YYYY-MM-DDTHH:MM:SS) <input id="newTime"></label>
+<label>Horário <input id="newTime" type="datetime-local"></label>
 <button id="addBtn">Adicionar</button>
 <script>
 async function load(){
@@ -31,7 +31,7 @@ async function load(){
     const tr=document.createElement('tr');
     tr.dataset.index=idx;
     tr.innerHTML=`<td><input data-field="name" value="${a.name}" disabled></td>`+
-      `<td><input data-field="time" value="${a.time}" disabled></td>`+
+      `<td><input data-field="time" type="datetime-local" value="${new Date(a.time).toISOString().slice(0,16)}" disabled></td>`+
       `<td><button data-action="edit">Editar</button>`+
       `<button data-action="save" style="display:none">Salvar</button>`+
       `<button data-action="delete">Excluir</button></td>`;

--- a/src/server.js
+++ b/src/server.js
@@ -121,8 +121,9 @@ app.post('/api/bingo', (req,res)=>{
 });
 
 app.post('/api/attraction', (req,res)=>{
-  const {time,name} = req.body;
-  data.attractions.push({time,name});
+  const { time, name } = req.body;
+  const iso = new Date(time).toISOString();
+  data.attractions.push({ time: iso, name });
   res.end();
 });
 
@@ -134,7 +135,8 @@ app.put('/api/attraction/:index', (req,res)=>{
   const idx = parseInt(req.params.index,10);
   if (Number.isNaN(idx) || !data.attractions[idx]) return res.status(404).end();
   const { time, name } = req.body;
-  data.attractions[idx] = { time, name };
+  const iso = new Date(time).toISOString();
+  data.attractions[idx] = { time: iso, name };
   res.end();
 });
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -15,23 +15,22 @@ describe('Express API', () => {
     expect(res.body.players.Alice).toBe('blue');
   });
 
-codex/implementar-página-lineup
   it('manages attractions', async () => {
     await request(app)
       .post('/api/attraction')
-      .send({ name: 'Show', time: '2023-01-01T10:00:00' })
+      .send({ name: 'Show', time: '2023-01-01T10:00' })
       .expect(200);
 
     await request(app)
       .put('/api/attraction/0')
-      .send({ name: 'Show 2', time: '2023-01-01T11:00:00' })
+      .send({ name: 'Show 2', time: '2023-01-01T11:00' })
       .expect(200);
 
     const list = await request(app)
       .get('/api/attractions')
       .expect(200);
 
-    expect(list.body[0]).toEqual({ name: 'Show 2', time: '2023-01-01T11:00:00' });
+    expect(list.body[0]).toEqual({ name: 'Show 2', time: '2023-01-01T11:00:00.000Z' });
 
     await request(app)
       .delete('/api/attraction/0')
@@ -42,6 +41,7 @@ codex/implementar-página-lineup
       .expect(200);
 
     expect(empty.body).toEqual([]);
+  });
 
   it('updates points configuration', async () => {
     await request(app)
@@ -54,6 +54,5 @@ codex/implementar-página-lineup
       .expect(200);
 
     expect(res.body.points.bullFirst).toBe(99);
-main
   });
 });


### PR DESCRIPTION
## Summary
- change lineup page to use `datetime-local` fields
- store attraction times in ISO format
- adjust server tests for new timestamp format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848ee28845c83319450342d0a839d60