### PR TITLE
split admin panel into individual pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,15 @@ The provided Dockerfile uses the official `node:20` image as its base. You can s
 docker run -p 3000:3000 arraia
 ```
 
-
-Then access `http://localhost:3000/` for slides, 
-`http://localhost:3000/admin.html` for the admin panel 
-`http://localhost:3000/pontos.html` to configure scoring.
-`http://localhost:3000/players.html`.
-`http://localhost:3000/lineup.html` for the lineup editor.
+Then access `http://localhost:3000/` for slides,
+`http://localhost:3000/admin.html` for the admin menu,
+`http://localhost:3000/players.html` to manage players,
+`http://localhost:3000/teams.html` to edit team names,
+`http://localhost:3000/bull.html` to register bull times,
+`http://localhost:3000/cotton.html` for cotonete battles,
+`http://localhost:3000/beer.html` for beer pong results,
+`http://localhost:3000/pacal.html` for pacal duels,
+`http://localhost:3000/bingo.html` to register bingo winners,
+`http://localhost:3000/pontos.html` to configure scoring,
+`http://localhost:3000/lineup.html` for the lineup editor,
+`http://localhost:3000/reset.html` to reset all data.

--- a/public/admin.html
+++ b/public/admin.html
@@ -15,6 +15,42 @@ body{font-family:sans-serif;display:flex;flex-wrap:wrap;gap:20px;padding:20px;}
   <span class="emoji">👥</span>
   <span class="label">Jogadores</span>
 </a>
+<a class="menu-item" href="teams.html">
+  <span class="emoji">🎽</span>
+  <span class="label">Times</span>
+</a>
+<a class="menu-item" href="bull.html">
+  <span class="emoji">🐂</span>
+  <span class="label">Touro</span>
+</a>
+<a class="menu-item" href="cotton.html">
+  <span class="emoji">⚔️</span>
+  <span class="label">Cotonete</span>
+</a>
+<a class="menu-item" href="beer.html">
+  <span class="emoji">🍺</span>
+  <span class="label">Beer Pong</span>
+</a>
+<a class="menu-item" href="pacal.html">
+  <span class="emoji">🎯</span>
+  <span class="label">Pacal</span>
+</a>
+<a class="menu-item" href="bingo.html">
+  <span class="emoji">🎲</span>
+  <span class="label">Bingo</span>
+</a>
+<a class="menu-item" href="lineup.html">
+  <span class="emoji">📅</span>
+  <span class="label">Lineup</span>
+</a>
+<a class="menu-item" href="pontos.html">
+  <span class="emoji">🏅</span>
+  <span class="label">Pontos</span>
+</a>
+<a class="menu-item" href="reset.html">
+  <span class="emoji">♻️</span>
+  <span class="label">Reset</span>
+</a>
 <a class="menu-item" href="manage.html">
   <span class="emoji">🛠️</span>
   <span class="label">Painel Completo</span>

--- a/public/beer.html
+++ b/public/beer.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+<meta charset="UTF-8">
+<title>Beer Pong</title>
+<style>
+body{font-family:sans-serif;padding:20px;}
+label{display:block;margin-top:10px;}
+</style>
+</head>
+<body>
+<h1>Beer Pong</h1>
+<label>Time1 Jogador1 <input id="beerT1P1" list="players"></label>
+<label>Time1 Jogador2 <input id="beerT1P2" list="players"></label>
+<label>Time2 Jogador1 <input id="beerT2P1" list="players"></label>
+<label>Time2 Jogador2 <input id="beerT2P2" list="players"></label>
+<label>Vencedor <input id="beerWin" list="players"></label>
+<button onclick="addBeer()">Registrar</button>
+<datalist id="players"></datalist>
+<script>
+function post(url,data){fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});}
+let players={};
+function loadPlayers(){fetch('/api/players').then(r=>r.json()).then(p=>{players=p;playersElem.innerHTML=Object.keys(p).map(n=>`<option value="${n}">`).join('');});}
+function ensurePlayer(name){if(!name||players[name])return;const team=prompt(`Time para ${name}? (blue/yellow)`);if(team){post('/api/player',{name,team});players[name]=team;playersElem.innerHTML=Object.keys(players).map(n=>`<option value="${n}">`).join('');}}
+function addBeer(){[beerT1P1.value,beerT1P2.value,beerT2P1.value,beerT2P2.value,beerWin.value].forEach(ensurePlayer);post('/api/beer',{team1:[beerT1P1.value,beerT1P2.value],team2:[beerT2P1.value,beerT2P2.value],winner:beerWin.value});beerT1P1.value='';beerT1P2.value='';beerT2P1.value='';beerT2P2.value='';beerWin.value='';}
+const playersElem=document.getElementById('players');
+loadPlayers();
+</script>
+</body>
+</html>

--- a/public/bingo.html
+++ b/public/bingo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+<meta charset="UTF-8">
+<title>Bingo</title>
+<style>
+body{font-family:sans-serif;padding:20px;}
+label{display:block;margin-top:10px;}
+</style>
+</head>
+<body>
+<h1>Bingo</h1>
+<label>1º <input id="bingo1" list="players"></label>
+<label>2º <input id="bingo2" list="players"></label>
+<label>3º <input id="bingo3" list="players"></label>
+<button onclick="addBingo()">Registrar</button>
+<datalist id="players"></datalist>
+<script>
+function post(url,data){fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});}
+let players={};
+function loadPlayers(){fetch('/api/players').then(r=>r.json()).then(p=>{players=p;playersElem.innerHTML=Object.keys(p).map(n=>`<option value="${n}">`).join('');});}
+function ensurePlayer(name){if(!name||players[name])return;const team=prompt(`Time para ${name}? (blue/yellow)`);if(team){post('/api/player',{name,team});players[name]=team;playersElem.innerHTML=Object.keys(players).map(n=>`<option value="${n}">`).join('');}}
+function addBingo(){[bingo1.value,bingo2.value,bingo3.value].forEach(ensurePlayer);post('/api/bingo',{first:bingo1.value,second:bingo2.value,third:bingo3.value});bingo1.value='';bingo2.value='';bingo3.value='';}
+const playersElem=document.getElementById('players');
+loadPlayers();
+</script>
+</body>
+</html>

--- a/public/bull.html
+++ b/public/bull.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+<meta charset="UTF-8">
+<title>Touro Mecânico</title>
+<style>
+body{font-family:sans-serif;padding:20px;}
+label{display:block;margin-top:10px;}
+</style>
+</head>
+<body>
+<h1>Touro Mecânico</h1>
+<label>Jogador <input id="bullPlayer" list="players"></label>
+<label>Tempo <input id="bullTime" type="number"></label>
+<button onclick="addBull()">Registrar</button>
+<datalist id="players"></datalist>
+<script>
+function post(url,data){fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});}
+let players={};
+function loadPlayers(){fetch('/api/players').then(r=>r.json()).then(p=>{players=p;playersElem.innerHTML=Object.keys(p).map(n=>`<option value="${n}">`).join('');});}
+function ensurePlayer(name){if(!name||players[name])return;const team=prompt(`Time para ${name}? (blue/yellow)`);if(team){post('/api/player',{name,team});players[name]=team;playersElem.innerHTML=Object.keys(players).map(n=>`<option value="${n}">`).join('');}}
+function addBull(){ensurePlayer(bullPlayer.value);post('/api/bull',{name:bullPlayer.value,time:bullTime.value});bullPlayer.value='';bullTime.value='';}
+const playersElem=document.getElementById('players');
+loadPlayers();
+</script>
+</body>
+</html>

--- a/public/cotton.html
+++ b/public/cotton.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+<meta charset="UTF-8">
+<title>Guerra de Cotonete</title>
+<style>
+body{font-family:sans-serif;padding:20px;}
+label{display:block;margin-top:10px;}
+</style>
+</head>
+<body>
+<h1>Guerra de Cotonete</h1>
+<label>P1 <input id="cottonP1" list="players"></label>
+<label>P2 <input id="cottonP2" list="players"></label>
+<label>Vencedor <input id="cottonWin" list="players"></label>
+<button onclick="addCotton()">Registrar</button>
+<datalist id="players"></datalist>
+<script>
+function post(url,data){fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});}
+let players={};
+function loadPlayers(){fetch('/api/players').then(r=>r.json()).then(p=>{players=p;playersElem.innerHTML=Object.keys(p).map(n=>`<option value="${n}">`).join('');});}
+function ensurePlayer(name){if(!name||players[name])return;const team=prompt(`Time para ${name}? (blue/yellow)`);if(team){post('/api/player',{name,team});players[name]=team;playersElem.innerHTML=Object.keys(players).map(n=>`<option value="${n}">`).join('');}}
+function addCotton(){[cottonP1.value,cottonP2.value,cottonWin.value].forEach(ensurePlayer);post('/api/cotton',{p1:cottonP1.value,p2:cottonP2.value,winner:cottonWin.value});cottonP1.value='';cottonP2.value='';cottonWin.value='';}
+const playersElem=document.getElementById('players');
+loadPlayers();
+</script>
+</body>
+</html>

--- a/public/pacal.html
+++ b/public/pacal.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+<meta charset="UTF-8">
+<title>Pacal</title>
+<style>
+body{font-family:sans-serif;padding:20px;}
+label{display:block;margin-top:10px;}
+</style>
+</head>
+<body>
+<h1>Pacal</h1>
+<label>P1 <input id="pacalP1" list="players"></label>
+<label>P2 <input id="pacalP2" list="players"></label>
+<label>Vencedor <input id="pacalWin" list="players"></label>
+<button onclick="addPacal()">Registrar</button>
+<datalist id="players"></datalist>
+<script>
+function post(url,data){fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});}
+let players={};
+function loadPlayers(){fetch('/api/players').then(r=>r.json()).then(p=>{players=p;playersElem.innerHTML=Object.keys(p).map(n=>`<option value="${n}">`).join('');});}
+function ensurePlayer(name){if(!name||players[name])return;const team=prompt(`Time para ${name}? (blue/yellow)`);if(team){post('/api/player',{name,team});players[name]=team;playersElem.innerHTML=Object.keys(players).map(n=>`<option value="${n}">`).join('');}}
+function addPacal(){[pacalP1.value,pacalP2.value,pacalWin.value].forEach(ensurePlayer);post('/api/pacal',{p1:pacalP1.value,p2:pacalP2.value,winner:pacalWin.value});pacalP1.value='';pacalP2.value='';pacalWin.value='';}
+const playersElem=document.getElementById('players');
+loadPlayers();
+</script>
+</body>
+</html>

--- a/public/reset.html
+++ b/public/reset.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+<meta charset="UTF-8">
+<title>Resetar Dados</title>
+<style>
+body{font-family:sans-serif;padding:20px;}
+</style>
+</head>
+<body>
+<h1>Resetar Dados</h1>
+<button onclick="resetAll()">Zerar Tudo</button>
+<script>
+function resetAll(){fetch('/api/reset',{method:'POST'});}
+</script>
+</body>
+</html>

--- a/public/teams.html
+++ b/public/teams.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+<meta charset="UTF-8">
+<title>Nomes dos Times</title>
+<style>
+body{font-family:sans-serif;padding:20px;}
+label{display:block;margin-top:10px;}
+</style>
+</head>
+<body>
+<h1>Nomes dos Times</h1>
+<label>Nome do time azul <input id="teamBlue"></label>
+<label>Nome do time amarelo <input id="teamYellow"></label>
+<button onclick="saveTeams()">Salvar</button>
+<script>
+function saveTeams(){
+  fetch('/api/config/teamNames',{
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({blue:teamBlue.value,yellow:teamYellow.value})
+  });
+}
+fetch('/api/state').then(r=>r.json()).then(s=>{
+  teamBlue.value=s.teamNames.blue||'';
+  teamYellow.value=s.teamNames.yellow||'';
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace `admin.html` menu with links to new pages
- create individual pages to manage team names, bull, cotton, beer, pacal, bingo and reset actions
- document the new pages in `README.md`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f297139483319644a69f5a83f1ca