### PR TITLE
Update gitignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 node_modules
+
+# Logs
+npm-debug.log*
+
+# macOS
+.DS_Store


### PR DESCRIPTION
## Summary
- extend `.gitignore` with npm debug logs and macOS metadata files

## Testing
- `npm test` *(fails: ReferenceError codex/main defined in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6848f6f7ed7c8331bb4ce792ae13ee78