### PR TITLE
Implement bull competition finalize button

### DIFF
--- a/public/bull.html
+++ b/public/bull.html
@@ -13,6 +13,8 @@ label{display:block;margin-top:10px;}
 <label>Jogador <input id="bullPlayer" list="players"></label>
 <label>Tempo <input id="bullTime" type="number"></label>
 <button onclick="addBull()">Registrar</button>
+<button id="finishBtn" onclick="confirmFinish()">Finalizar Competição</button>
+<button id="newBtn" onclick="newCompetition()" style="display:none">Nova Competição</button>
 <datalist id="players"></datalist>
 <script>
 function post(url,data){fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});}
@@ -21,7 +23,16 @@ function loadPlayers(){fetch('/api/players').then(r=>r.json()).then(p=>{players=
 function ensurePlayer(name){if(!name||players[name])return;const team=prompt(`Time para ${name}? (blue/yellow)`);if(team){post('/api/player',{name,team});players[name]=team;playersElem.innerHTML=Object.keys(players).map(n=>`<option value="${n}">`).join('');}}
 function addBull(){ensurePlayer(bullPlayer.value);post('/api/bull',{name:bullPlayer.value,time:bullTime.value});bullPlayer.value='';bullTime.value='';}
 const playersElem=document.getElementById('players');
+const finishBtn=document.getElementById('finishBtn');
+const newBtn=document.getElementById('newBtn');
+function confirmFinish(){
+  const ans=prompt("Digite 'arraiadolowis' para confirmar");
+  if(ans==='arraiadolowis'){post('/api/bull/finish',{});finishBtn.style.display='none';newBtn.style.display='inline';}
+}
+function newCompetition(){post('/api/bull/new',{});newBtn.style.display='none';finishBtn.style.display='inline';}
+function loadState(){fetch('/api/state').then(r=>r.json()).then(s=>{if(s.bullFinished){finishBtn.style.display='none';newBtn.style.display='inline';}});}
 loadPlayers();
+loadState();
 </script>
 </body>
 </html>

--- a/src/server.js
+++ b/src/server.js
@@ -12,6 +12,7 @@ app.use(express.static(path.join(__dirname, '..', 'public')));
 const data = {
   players: {}, // name -> team
   bullTimes: [], // {name, time}
+  bullFinished: false,
   cottonWars: [], // {p1, p2, winner}
   beerPongs: [], // {team1:[a,b], team2:[c,d], winner}
   pacalWars: [], // {p1,p2,winner}
@@ -36,7 +37,7 @@ const data = {
 
 function computeScores() {
   data.scores = {blue:0, yellow:0};
-  if (data.bullTimes.length > 0) {
+  if (data.bullFinished && data.bullTimes.length > 0) {
     const keys = ['bullFirst','bullSecond','bullThird','bullFourth','bullFifth'];
     const sorted = [...data.bullTimes].sort((a,b)=>a.time-b.time).slice(0, keys.length);
     sorted.forEach((r,i)=>{
@@ -109,6 +110,17 @@ app.post('/api/bull', (req,res)=>{
   res.end();
 });
 
+app.post('/api/bull/finish', (req,res)=>{
+  data.bullFinished = true;
+  res.end();
+});
+
+app.post('/api/bull/new', (req,res)=>{
+  data.bullTimes = [];
+  data.bullFinished = false;
+  res.end();
+});
+
 app.post('/api/cotton', (req,res)=>{
   const {p1,p2,winner} = req.body;
   data.cottonWars.push({p1,p2,winner});
@@ -175,7 +187,7 @@ app.post('/api/config/points', (req,res)=>{
 
 app.post('/api/reset', (req,res)=>{
   Object.assign(data, {
-    players:{}, bullTimes:[], cottonWars:[], beerPongs:[], pacalWars:[], bingoWinners:null, attractions:[], scores:{blue:0,yellow:0}
+    players:{}, bullTimes:[], bullFinished:false, cottonWars:[], beerPongs:[], pacalWars:[], bingoWinners:null, attractions:[], scores:{blue:0,yellow:0}
   });
   res.end();
 });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -74,4 +74,18 @@ describe('Express API', () => {
     expect(res.body.scores.yellow).toBe(0);
     expect('undefined' in res.body.scores).toBe(false);
   });
+
+  it('only scores bull when finished', async () => {
+    await request(app).post('/api/reset').expect(200);
+    await request(app).post('/api/player').send({ name: 'Alice', team: 'blue' }).expect(200);
+    await request(app).post('/api/bull').send({ name: 'Alice', time: 5 }).expect(200);
+
+    let res = await request(app).get('/api/state').expect(200);
+    expect(res.body.scores.blue).toBe(0);
+
+    await request(app).post('/api/bull/finish').expect(200);
+
+    res = await request(app).get('/api/state').expect(200);
+    expect(res.body.scores.blue).toBe(res.body.points.bullFirst);
+  });
 });


### PR DESCRIPTION
## Summary
- add a `bullFinished` flag on the server
- compute bull scores only after finishing
- expose `/api/bull/finish` and `/api/bull/new` endpoints
- update reset endpoint to clear bull state
- add confirmation and new competition buttons on the bull page
- test that bull scores are counted only after finishing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848f96ef8d88331823c38ba82b33bb4