### PR TITLE
Update beer pong winner selection

### DIFF
--- a/public/beer.html
+++ b/public/beer.html
@@ -10,21 +10,32 @@ label{display:block;margin-top:10px;}
 </head>
 <body>
 <h1>Beer Pong</h1>
-<label>Time1 Jogador1 <input id="beerT1P1" list="players"></label>
-<label>Time1 Jogador2 <input id="beerT1P2" list="players"></label>
-<label>Time2 Jogador1 <input id="beerT2P1" list="players"></label>
-<label>Time2 Jogador2 <input id="beerT2P2" list="players"></label>
-<label>Vencedor <input id="beerWin" list="players"></label>
+<label>Jogador1 (Time Azul) <input id="beerBlueP1" list="playersBlue"></label>
+<label>Jogador2 (Time Azul) <input id="beerBlueP2" list="playersBlue"></label>
+<label>Jogador1 (Time Amarelo) <input id="beerYellowP1" list="playersYellow"></label>
+<label>Jogador2 (Time Amarelo) <input id="beerYellowP2" list="playersYellow"></label>
+<label>Vencedor <select id="beerWin"></select></label>
 <button onclick="addBeer()">Registrar</button>
-<datalist id="players"></datalist>
+<datalist id="playersBlue"></datalist>
+<datalist id="playersYellow"></datalist>
 <script>
 function post(url,data){fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});}
 let players={};
-function loadPlayers(){fetch('/api/players').then(r=>r.json()).then(p=>{players=p;playersElem.innerHTML=Object.keys(p).map(n=>`<option value="${n}">`).join('');});}
-function ensurePlayer(name){if(!name||players[name])return;const team=prompt(`Time para ${name}? (blue/yellow)`);if(team){post('/api/player',{name,team});players[name]=team;playersElem.innerHTML=Object.keys(players).map(n=>`<option value="${n}">`).join('');}}
-function addBeer(){[beerT1P1.value,beerT1P2.value,beerT2P1.value,beerT2P2.value,beerWin.value].forEach(ensurePlayer);post('/api/beer',{team1:[beerT1P1.value,beerT1P2.value],team2:[beerT2P1.value,beerT2P2.value],winner:beerWin.value});beerT1P1.value='';beerT1P2.value='';beerT2P1.value='';beerT2P2.value='';beerWin.value='';}
-const playersElem=document.getElementById('players');
+let teamNames={blue:'Azul',yellow:'Amarelo'};
+function loadPlayers(){fetch('/api/players').then(r=>r.json()).then(p=>{players=p;updateLists();});}
+function updateLists(){
+  const blue=Object.keys(players).filter(n=>players[n]==='blue');
+  const yellow=Object.keys(players).filter(n=>players[n]==='yellow');
+  playersBlueElem.innerHTML=blue.map(n=>`<option value="${n}">`).join('');
+  playersYellowElem.innerHTML=yellow.map(n=>`<option value="${n}">`).join('');
+}
+function loadTeams(){fetch('/api/state').then(r=>r.json()).then(s=>{teamNames=s.teamNames;beerWin.innerHTML=`<option value="blue">${teamNames.blue}</option><option value="yellow">${teamNames.yellow}</option>`;});}
+function ensurePlayer(name,teamHint){if(!name||players[name])return;const team=teamHint||prompt(`Time para ${name}? (blue/yellow)`);if(team){post('/api/player',{name,team});players[name]=team;updateLists();}}
+function addBeer(){[beerBlueP1.value,beerBlueP2.value].forEach(n=>ensurePlayer(n,'blue'));[beerYellowP1.value,beerYellowP2.value].forEach(n=>ensurePlayer(n,'yellow'));post('/api/beer',{team1:[beerBlueP1.value,beerBlueP2.value],team2:[beerYellowP1.value,beerYellowP2.value],winner:beerWin.value});beerBlueP1.value='';beerBlueP2.value='';beerYellowP1.value='';beerYellowP2.value='';beerWin.value='';}
+const playersBlueElem=document.getElementById('playersBlue');
+const playersYellowElem=document.getElementById('playersYellow');
 loadPlayers();
+loadTeams();
 </script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -48,7 +48,7 @@ function render(){
   }
   if(state.beerPongs.length>0){
     let html='<h1>Beer Pong</h1><ul>';
-    state.beerPongs.slice(-5).forEach(b=>{html+=`<li>${b.team1.map(p=>`<span class="team-${state.players[p]}">${p}</span>`).join(' & ')} vs ${b.team2.map(p=>`<span class="team-${state.players[p]}">${p}</span>`).join(' & ')} 🏆 <span class="team-${state.players[b.winner]}">${b.winner}</span></li>`});
+    state.beerPongs.slice(-5).forEach(b=>{html+=`<li>${b.team1.map(p=>`<span class="team-${state.players[p]}">${p}</span>`).join(' & ')} vs ${b.team2.map(p=>`<span class="team-${state.players[p]}">${p}</span>`).join(' & ')} 🏆 <span class="team-${b.winner}">${state.teamNames[b.winner]}</span></li>`});
     html+='</ul>';
     slides.push({bg:'orange',html});
   }

--- a/public/manage.html
+++ b/public/manage.html
@@ -40,11 +40,11 @@ label{display:block;margin-top:10px;}
 <hr>
 <div>
 <h2>Beer Pong</h2>
-<label>Time1 Jogador1 <input id="beerT1P1" list="players"/></label>
-<label>Time1 Jogador2 <input id="beerT1P2" list="players"/></label>
-<label>Time2 Jogador1 <input id="beerT2P1" list="players"/></label>
-<label>Time2 Jogador2 <input id="beerT2P2" list="players"/></label>
-<label>Vencedor <input id="beerWin" list="players"/></label>
+<label>Jogador1 (Time Azul) <input id="beerBlueP1" list="playersBlue"/></label>
+<label>Jogador2 (Time Azul) <input id="beerBlueP2" list="playersBlue"/></label>
+<label>Jogador1 (Time Amarelo) <input id="beerYellowP1" list="playersYellow"/></label>
+<label>Jogador2 (Time Amarelo) <input id="beerYellowP2" list="playersYellow"/></label>
+<label>Vencedor <select id="beerWin"></select></label>
 <button onclick="addBeer()">Registrar</button>
 </div>
 <hr>
@@ -78,23 +78,42 @@ label{display:block;margin-top:10px;}
 <ul id="scoreBoard"></ul>
 </div>
 <datalist id="players"></datalist>
+<datalist id="playersBlue"></datalist>
+<datalist id="playersYellow"></datalist>
 <script>
 function post(url,data){fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});}
 let players = {};
+let teamNames={blue:'Azul',yellow:'Amarelo'};
 function loadPlayers(){fetch('/api/players').then(r=>r.json()).then(p=>{players=p;updateDatalist();});}
-function updateDatalist(){playersElem.innerHTML=Object.keys(players).map(n=>`<option value="${n}">`).join('');}
-function ensurePlayer(name){if(!name||players[name])return;const team=prompt(`Time para ${name}? (blue/yellow)`);if(team){post('/api/player',{name,team});players[name]=team;updateDatalist();}}
+function updateDatalist(){
+  playersElem.innerHTML=Object.keys(players).map(n=>`<option value="${n}">`).join('');
+  playersBlueElem.innerHTML=Object.keys(players).filter(n=>players[n]==='blue').map(n=>`<option value="${n}">`).join('');
+  playersYellowElem.innerHTML=Object.keys(players).filter(n=>players[n]==='yellow').map(n=>`<option value="${n}">`).join('');
+}
+function loadTeams(){fetch('/api/state').then(r=>r.json()).then(s=>{teamNames=s.teamNames;beerWin.innerHTML=`<option value="blue">${teamNames.blue}</option><option value="yellow">${teamNames.yellow}</option>`;});}
+function ensurePlayer(name,teamHint){if(!name||players[name])return;const team=teamHint||prompt(`Time para ${name}? (blue/yellow)`);if(team){post('/api/player',{name,team});players[name]=team;updateDatalist();}}
 function saveTeams(){post('/api/config/teamNames',{blue:teamBlue.value,yellow:teamYellow.value});}
 function addPlayer(){post('/api/player',{name:playerName.value,team:playerTeam.value});players[playerName.value]=playerTeam.value;updateDatalist();}
 function addBull(){ensurePlayer(bullPlayer.value);post('/api/bull',{name:bullPlayer.value,time:bullTime.value});}
 function addCotton(){[cottonP1.value,cottonP2.value,cottonWin.value].forEach(ensurePlayer);post('/api/cotton',{p1:cottonP1.value,p2:cottonP2.value,winner:cottonWin.value});}
-function addBeer(){[beerT1P1.value,beerT1P2.value,beerT2P1.value,beerT2P2.value,beerWin.value].forEach(ensurePlayer);post('/api/beer',{team1:[beerT1P1.value,beerT1P2.value],team2:[beerT2P1.value,beerT2P2.value],winner:beerWin.value});}
+function addBeer(){
+  [beerBlueP1.value,beerBlueP2.value].forEach(n=>ensurePlayer(n,'blue'));
+  [beerYellowP1.value,beerYellowP2.value].forEach(n=>ensurePlayer(n,'yellow'));
+  post('/api/beer',{
+    team1:[beerBlueP1.value,beerBlueP2.value],
+    team2:[beerYellowP1.value,beerYellowP2.value],
+    winner:beerWin.value
+  });
+}
 function addPacal(){[pacalP1.value,pacalP2.value,pacalWin.value].forEach(ensurePlayer);post('/api/pacal',{p1:pacalP1.value,p2:pacalP2.value,winner:pacalWin.value});}
 function addBingo(){[bingo1.value,bingo2.value,bingo3.value].forEach(ensurePlayer);post('/api/bingo',{first:bingo1.value,second:bingo2.value,third:bingo3.value});}
 function addAttraction(){post('/api/attraction',{time:attrTime.value,name:attrName.value});}
 function resetAll(){post('/api/reset',{});}
 const playersElem=document.getElementById('players');
+const playersBlueElem=document.getElementById('playersBlue');
+const playersYellowElem=document.getElementById('playersYellow');
 loadPlayers();
+loadTeams();
 function loadScore(){
   fetch('/api/state').then(r=>r.json()).then(s=>{
     const ul=document.getElementById('scoreBoard');

--- a/src/server.js
+++ b/src/server.js
@@ -13,7 +13,7 @@ const data = {
   players: {}, // name -> team
   bullTimes: [], // {name, time}
   cottonWars: [], // {p1, p2, winner}
-  beerPongs: [], // {team1:[a,b], team2:[c,d], winner}
+  beerPongs: [], // {team1:[a,b], team2:[c,d], winner:team}
   pacalWars: [], // {p1,p2,winner}
   bingoWinners: null, // {first,second,third}
   attractions: [], // {time, name}
@@ -52,7 +52,7 @@ function computeScores() {
     if(team) data.scores[team] += data.points.cottonWin;
   });
   data.beerPongs.forEach(b=>{
-    const team = data.players[b.winner];
+    const team = b.winner; // winner is stored as team
     if(team) data.scores[team] += data.points.beerWin;
   });
   data.pacalWars.forEach(b=>{


### PR DESCRIPTION
## Summary
- store beer pong winner by team instead of player
- restrict beer pong inputs to team members
- display team names on beer pong winner select

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848fa38779883319d2f5117e4645b71