### PR TITLE
Add record history with edit/delete

### DIFF
--- a/public/beer.html
+++ b/public/beer.html
@@ -17,6 +17,8 @@ label{display:block;margin-top:10px;}
 <label>Vencedor <input id="beerWin" list="players"></label>
 <button onclick="addBeer()">Registrar</button>
 <datalist id="players"></datalist>
+<h2>Histórico</h2>
+<table id="hist"></table>
 <script>
 function post(url,data){fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});}
 let players={};
@@ -24,7 +26,33 @@ function loadPlayers(){fetch('/api/players').then(r=>r.json()).then(p=>{players=
 function ensurePlayer(name){if(!name||players[name])return;const team=prompt(`Time para ${name}? (blue/yellow)`);if(team){post('/api/player',{name,team});players[name]=team;playersElem.innerHTML=Object.keys(players).map(n=>`<option value="${n}">`).join('');}}
 function addBeer(){[beerT1P1.value,beerT1P2.value,beerT2P1.value,beerT2P2.value,beerWin.value].forEach(ensurePlayer);post('/api/beer',{team1:[beerT1P1.value,beerT1P2.value],team2:[beerT2P1.value,beerT2P2.value],winner:beerWin.value});beerT1P1.value='';beerT1P2.value='';beerT2P1.value='';beerT2P2.value='';beerWin.value='';}
 const playersElem=document.getElementById('players');
+function loadHistory(){
+  fetch('/api/state').then(r=>r.json()).then(s=>{
+    const rows=s.beerPongs.map((b,i)=>`<tr>
+      <td><input data-i="${i}" class="t1p1" value="${b.team1[0]}" list="players"></td>
+      <td><input data-i="${i}" class="t1p2" value="${b.team1[1]}" list="players"></td>
+      <td><input data-i="${i}" class="t2p1" value="${b.team2[0]}" list="players"></td>
+      <td><input data-i="${i}" class="t2p2" value="${b.team2[1]}" list="players"></td>
+      <td><input data-i="${i}" class="win" value="${b.winner}" list="players"></td>
+      <td><button onclick="save(${i})">Salvar</button><button onclick="del(${i})">Excluir</button></td>
+    </tr>`).join('');
+    document.getElementById('hist').innerHTML=`<tbody>${rows}</tbody>`;
+  });
+}
+function save(i){
+  const t1p1=document.querySelector(`input.t1p1[data-i="${i}"]`).value;
+  const t1p2=document.querySelector(`input.t1p2[data-i="${i}"]`).value;
+  const t2p1=document.querySelector(`input.t2p1[data-i="${i}"]`).value;
+  const t2p2=document.querySelector(`input.t2p2[data-i="${i}"]`).value;
+  const win=document.querySelector(`input.win[data-i="${i}"]`).value;
+  [t1p1,t1p2,t2p1,t2p2,win].forEach(ensurePlayer);
+  fetch('/api/beer/'+i,{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({team1:[t1p1,t1p2],team2:[t2p1,t2p2],winner:win})}).then(loadHistory);
+}
+function del(i){
+  fetch('/api/beer/'+i,{method:'DELETE'}).then(loadHistory);
+}
 loadPlayers();
+loadHistory();
 </script>
 </body>
 </html>

--- a/public/bingo.html
+++ b/public/bingo.html
@@ -15,6 +15,8 @@ label{display:block;margin-top:10px;}
 <label>3º <input id="bingo3" list="players"></label>
 <button onclick="addBingo()">Registrar</button>
 <datalist id="players"></datalist>
+<h2>Histórico</h2>
+<table id="hist"></table>
 <script>
 function post(url,data){fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});}
 let players={};
@@ -22,7 +24,30 @@ function loadPlayers(){fetch('/api/players').then(r=>r.json()).then(p=>{players=
 function ensurePlayer(name){if(!name||players[name])return;const team=prompt(`Time para ${name}? (blue/yellow)`);if(team){post('/api/player',{name,team});players[name]=team;playersElem.innerHTML=Object.keys(players).map(n=>`<option value="${n}">`).join('');}}
 function addBingo(){[bingo1.value,bingo2.value,bingo3.value].forEach(ensurePlayer);post('/api/bingo',{first:bingo1.value,second:bingo2.value,third:bingo3.value});bingo1.value='';bingo2.value='';bingo3.value='';}
 const playersElem=document.getElementById('players');
+function loadHistory(){
+  fetch('/api/state').then(r=>r.json()).then(s=>{
+    const b=s.bingoWinners||{first:'',second:'',third:''};
+    const row=`<tr>
+      <td><input id="h1" value="${b.first||''}" list="players"></td>
+      <td><input id="h2" value="${b.second||''}" list="players"></td>
+      <td><input id="h3" value="${b.third||''}" list="players"></td>
+      <td><button onclick="save()">Salvar</button><button onclick="del()">Excluir</button></td>
+    </tr>`;
+    document.getElementById('hist').innerHTML=`<tbody>${row}</tbody>`;
+  });
+}
+function save(){
+  const first=document.getElementById('h1').value;
+  const second=document.getElementById('h2').value;
+  const third=document.getElementById('h3').value;
+  [first,second,third].forEach(ensurePlayer);
+  fetch('/api/bingo',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({first,second,third})}).then(loadHistory);
+}
+function del(){
+  fetch('/api/bingo',{method:'DELETE'}).then(loadHistory);
+}
 loadPlayers();
+loadHistory();
 </script>
 </body>
 </html>

--- a/public/bull.html
+++ b/public/bull.html
@@ -14,6 +14,8 @@ label{display:block;margin-top:10px;}
 <label>Tempo <input id="bullTime" type="number"></label>
 <button onclick="addBull()">Registrar</button>
 <datalist id="players"></datalist>
+<h2>Histórico</h2>
+<table id="hist"></table>
 <script>
 function post(url,data){fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});}
 let players={};
@@ -21,7 +23,27 @@ function loadPlayers(){fetch('/api/players').then(r=>r.json()).then(p=>{players=
 function ensurePlayer(name){if(!name||players[name])return;const team=prompt(`Time para ${name}? (blue/yellow)`);if(team){post('/api/player',{name,team});players[name]=team;playersElem.innerHTML=Object.keys(players).map(n=>`<option value="${n}">`).join('');}}
 function addBull(){ensurePlayer(bullPlayer.value);post('/api/bull',{name:bullPlayer.value,time:bullTime.value});bullPlayer.value='';bullTime.value='';}
 const playersElem=document.getElementById('players');
+function loadHistory(){
+  fetch('/api/state').then(r=>r.json()).then(s=>{
+    const rows=s.bullTimes.map((b,i)=>`<tr>
+      <td><input data-i="${i}" class="name" value="${b.name}" list="players"></td>
+      <td><input data-i="${i}" class="time" type="number" value="${b.time}"></td>
+      <td><button onclick="save(${i})">Salvar</button><button onclick="del(${i})">Excluir</button></td>
+    </tr>`).join('');
+    document.getElementById('hist').innerHTML=`<tbody>${rows}</tbody>`;
+  });
+}
+function save(i){
+  const name=document.querySelector(`input.name[data-i="${i}"]`).value;
+  const time=document.querySelector(`input.time[data-i="${i}"]`).value;
+  ensurePlayer(name);
+  fetch('/api/bull/'+i,{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({name,time})}).then(loadHistory);
+}
+function del(i){
+  fetch('/api/bull/'+i,{method:'DELETE'}).then(loadHistory);
+}
 loadPlayers();
+loadHistory();
 </script>
 </body>
 </html>

--- a/public/cotton.html
+++ b/public/cotton.html
@@ -15,6 +15,8 @@ label{display:block;margin-top:10px;}
 <label>Vencedor <input id="cottonWin" list="players"></label>
 <button onclick="addCotton()">Registrar</button>
 <datalist id="players"></datalist>
+<h2>Histórico</h2>
+<table id="hist"></table>
 <script>
 function post(url,data){fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});}
 let players={};
@@ -22,7 +24,29 @@ function loadPlayers(){fetch('/api/players').then(r=>r.json()).then(p=>{players=
 function ensurePlayer(name){if(!name||players[name])return;const team=prompt(`Time para ${name}? (blue/yellow)`);if(team){post('/api/player',{name,team});players[name]=team;playersElem.innerHTML=Object.keys(players).map(n=>`<option value="${n}">`).join('');}}
 function addCotton(){[cottonP1.value,cottonP2.value,cottonWin.value].forEach(ensurePlayer);post('/api/cotton',{p1:cottonP1.value,p2:cottonP2.value,winner:cottonWin.value});cottonP1.value='';cottonP2.value='';cottonWin.value='';}
 const playersElem=document.getElementById('players');
+function loadHistory(){
+  fetch('/api/state').then(r=>r.json()).then(s=>{
+    const rows=s.cottonWars.map((c,i)=>`<tr>
+      <td><input data-i="${i}" class="p1" value="${c.p1}" list="players"></td>
+      <td><input data-i="${i}" class="p2" value="${c.p2}" list="players"></td>
+      <td><input data-i="${i}" class="win" value="${c.winner}" list="players"></td>
+      <td><button onclick="save(${i})">Salvar</button><button onclick="del(${i})">Excluir</button></td>
+    </tr>`).join('');
+    document.getElementById('hist').innerHTML=`<tbody>${rows}</tbody>`;
+  });
+}
+function save(i){
+  const p1=document.querySelector(`input.p1[data-i="${i}"]`).value;
+  const p2=document.querySelector(`input.p2[data-i="${i}"]`).value;
+  const winner=document.querySelector(`input.win[data-i="${i}"]`).value;
+  [p1,p2,winner].forEach(ensurePlayer);
+  fetch('/api/cotton/'+i,{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({p1,p2,winner})}).then(loadHistory);
+}
+function del(i){
+  fetch('/api/cotton/'+i,{method:'DELETE'}).then(loadHistory);
+}
 loadPlayers();
+loadHistory();
 </script>
 </body>
 </html>

--- a/public/pacal.html
+++ b/public/pacal.html
@@ -15,6 +15,8 @@ label{display:block;margin-top:10px;}
 <label>Vencedor <input id="pacalWin" list="players"></label>
 <button onclick="addPacal()">Registrar</button>
 <datalist id="players"></datalist>
+<h2>Histórico</h2>
+<table id="hist"></table>
 <script>
 function post(url,data){fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});}
 let players={};
@@ -22,7 +24,29 @@ function loadPlayers(){fetch('/api/players').then(r=>r.json()).then(p=>{players=
 function ensurePlayer(name){if(!name||players[name])return;const team=prompt(`Time para ${name}? (blue/yellow)`);if(team){post('/api/player',{name,team});players[name]=team;playersElem.innerHTML=Object.keys(players).map(n=>`<option value="${n}">`).join('');}}
 function addPacal(){[pacalP1.value,pacalP2.value,pacalWin.value].forEach(ensurePlayer);post('/api/pacal',{p1:pacalP1.value,p2:pacalP2.value,winner:pacalWin.value});pacalP1.value='';pacalP2.value='';pacalWin.value='';}
 const playersElem=document.getElementById('players');
+function loadHistory(){
+  fetch('/api/state').then(r=>r.json()).then(s=>{
+    const rows=s.pacalWars.map((p,i)=>`<tr>
+      <td><input data-i="${i}" class="p1" value="${p.p1}" list="players"></td>
+      <td><input data-i="${i}" class="p2" value="${p.p2}" list="players"></td>
+      <td><input data-i="${i}" class="win" value="${p.winner}" list="players"></td>
+      <td><button onclick="save(${i})">Salvar</button><button onclick="del(${i})">Excluir</button></td>
+    </tr>`).join('');
+    document.getElementById('hist').innerHTML=`<tbody>${rows}</tbody>`;
+  });
+}
+function save(i){
+  const p1=document.querySelector(`input.p1[data-i="${i}"]`).value;
+  const p2=document.querySelector(`input.p2[data-i="${i}"]`).value;
+  const winner=document.querySelector(`input.win[data-i="${i}"]`).value;
+  [p1,p2,winner].forEach(ensurePlayer);
+  fetch('/api/pacal/'+i,{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({p1,p2,winner})}).then(loadHistory);
+}
+function del(i){
+  fetch('/api/pacal/'+i,{method:'DELETE'}).then(loadHistory);
+}
 loadPlayers();
+loadHistory();
 </script>
 </body>
 </html>

--- a/src/server.js
+++ b/src/server.js
@@ -109,9 +109,39 @@ app.post('/api/bull', (req,res)=>{
   res.end();
 });
 
+app.put('/api/bull/:index', (req,res)=>{
+  const idx = parseInt(req.params.index,10);
+  if(Number.isNaN(idx) || !data.bullTimes[idx]) return res.status(404).end();
+  const {name,time} = req.body;
+  data.bullTimes[idx] = {name,time:parseFloat(time)};
+  res.end();
+});
+
+app.delete('/api/bull/:index', (req,res)=>{
+  const idx = parseInt(req.params.index,10);
+  if(Number.isNaN(idx) || !data.bullTimes[idx]) return res.status(404).end();
+  data.bullTimes.splice(idx,1);
+  res.end();
+});
+
 app.post('/api/cotton', (req,res)=>{
   const {p1,p2,winner} = req.body;
   data.cottonWars.push({p1,p2,winner});
+  res.end();
+});
+
+app.put('/api/cotton/:index', (req,res)=>{
+  const idx = parseInt(req.params.index,10);
+  if(Number.isNaN(idx) || !data.cottonWars[idx]) return res.status(404).end();
+  const {p1,p2,winner} = req.body;
+  data.cottonWars[idx] = {p1,p2,winner};
+  res.end();
+});
+
+app.delete('/api/cotton/:index', (req,res)=>{
+  const idx = parseInt(req.params.index,10);
+  if(Number.isNaN(idx) || !data.cottonWars[idx]) return res.status(404).end();
+  data.cottonWars.splice(idx,1);
   res.end();
 });
 
@@ -121,15 +151,56 @@ app.post('/api/beer', (req,res)=>{
   res.end();
 });
 
+app.put('/api/beer/:index', (req,res)=>{
+  const idx = parseInt(req.params.index,10);
+  if(Number.isNaN(idx) || !data.beerPongs[idx]) return res.status(404).end();
+  const {team1,team2,winner} = req.body;
+  data.beerPongs[idx] = {team1,team2,winner};
+  res.end();
+});
+
+app.delete('/api/beer/:index', (req,res)=>{
+  const idx = parseInt(req.params.index,10);
+  if(Number.isNaN(idx) || !data.beerPongs[idx]) return res.status(404).end();
+  data.beerPongs.splice(idx,1);
+  res.end();
+});
+
 app.post('/api/pacal', (req,res)=>{
   const {p1,p2,winner} = req.body;
   data.pacalWars.push({p1,p2,winner});
   res.end();
 });
 
+app.put('/api/pacal/:index', (req,res)=>{
+  const idx = parseInt(req.params.index,10);
+  if(Number.isNaN(idx) || !data.pacalWars[idx]) return res.status(404).end();
+  const {p1,p2,winner} = req.body;
+  data.pacalWars[idx] = {p1,p2,winner};
+  res.end();
+});
+
+app.delete('/api/pacal/:index', (req,res)=>{
+  const idx = parseInt(req.params.index,10);
+  if(Number.isNaN(idx) || !data.pacalWars[idx]) return res.status(404).end();
+  data.pacalWars.splice(idx,1);
+  res.end();
+});
+
 app.post('/api/bingo', (req,res)=>{
   const {first,second,third} = req.body;
   data.bingoWinners = {first,second,third};
+  res.end();
+});
+
+app.put('/api/bingo', (req,res)=>{
+  const {first,second,third} = req.body;
+  data.bingoWinners = {first,second,third};
+  res.end();
+});
+
+app.delete('/api/bingo', (req,res)=>{
+  data.bingoWinners = null;
   res.end();
 });
 


### PR DESCRIPTION
## Summary
- allow editing and removal of bull, cotonete, beer pong, pacal and bingo records
- show editable history tables on each admin page
- expose update and delete endpoints for all games

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848fb3067548331adf872705e12376b