### PR TITLE
Add background image support for slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,14 @@ This project provides a simple slide show and admin panel for a local party scor
   5. **Pacal** battle history.
   6. **Current and next attraction** based on the schedule, including a countdown.
   7. **Overall team score** using a horizontal bar chart with the winning team on top and a trophy.
-- Every slide has a custom background color.
+  - Slides use custom background images. Place image files in `public/backgrounds` with the following names so they load automatically:
+    - `bull.jpg` - Top Touro
+    - `cotton.jpg` - Guerra de Cotonete
+    - `bingo.jpg` - Bingo
+    - `beer.jpg` - Beer Pong
+    - `pacal.jpg` - Pacal
+    - `attractions.jpg` - Atrações
+    - `score.jpg` - Placar
 - Player names are shown in their team color (blue or yellow).
 - The Admin panel lets you:
   - Register players and choose their team.
@@ -50,3 +57,7 @@ Then access `http://localhost:3000/` for slides,
 `http://localhost:3000/pontos.html` to configure scoring,
 `http://localhost:3000/lineup.html` for the lineup editor,
 `http://localhost:3000/reset.html` to reset all data.
+
+### Background images
+
+Add your desired slide backgrounds in the `public/backgrounds` directory using the filenames listed above. When present, they will automatically be used in the slideshow.

--- a/public/index.html
+++ b/public/index.html
@@ -16,6 +16,15 @@ body,html{margin:0;padding:0;height:100%;width:100%;font-family:sans-serif;color
 <script>
 const slidesEl=document.getElementById('slides');
 let state={};
+const bgImages={
+  bull:'backgrounds/bull.jpg',
+  cotton:'backgrounds/cotton.jpg',
+  bingo:'backgrounds/bingo.jpg',
+  beer:'backgrounds/beer.jpg',
+  pacal:'backgrounds/pacal.jpg',
+  attractions:'backgrounds/attractions.jpg',
+  score:'backgrounds/score.jpg'
+};
 function render(){
   slidesEl.innerHTML='';
   const slides=[];
@@ -30,13 +39,13 @@ function render(){
         i++;
       });
       html+='</ol>';
-      slides.push({bg:'darkred',html});
+    slides.push({color:'darkred',image:bgImages.bull,html});
     }
   if(state.cottonWars.length>0){
     let html='<h1>Guerra de Cotonete</h1><ul>';
     state.cottonWars.slice(-5).forEach(b=>{html+=`<li><span class="team-${state.players[b.p1]}">${b.p1}</span> vs <span class="team-${state.players[b.p2]}">${b.p2}</span> 🏆 <span class="team-${state.players[b.winner]}">${b.winner}</span></li>`});
     html+='</ul>';
-    slides.push({bg:'green',html});
+    slides.push({color:'green',image:bgImages.cotton,html});
   }
   if(state.bingoWinners){
     let html='<h1>Bingo</h1><ol>';
@@ -44,19 +53,19 @@ function render(){
     html+=`<li><span class="team-${state.players[state.bingoWinners.second]}">${state.bingoWinners.second}</span></li>`;
     html+=`<li><span class="team-${state.players[state.bingoWinners.third]}">${state.bingoWinners.third}</span></li>`;
     html+='</ol>';
-    slides.push({bg:'purple',html});
+    slides.push({color:'purple',image:bgImages.bingo,html});
   }
   if(state.beerPongs.length>0){
     let html='<h1>Beer Pong</h1><ul>';
     state.beerPongs.slice(-5).forEach(b=>{html+=`<li>${b.team1.map(p=>`<span class="team-${state.players[p]}">${p}</span>`).join(' & ')} vs ${b.team2.map(p=>`<span class="team-${state.players[p]}">${p}</span>`).join(' & ')} 🏆 <span class="team-${b.winner}">${state.teamNames[b.winner]}</span></li>`});
     html+='</ul>';
-    slides.push({bg:'orange',html});
+    slides.push({color:'orange',image:bgImages.beer,html});
   }
   if(state.pacalWars.length>0){
     let html='<h1>Pacal</h1><ul>';
     state.pacalWars.slice(-5).forEach(b=>{html+=`<li><span class="team-${state.players[b.p1]}">${b.p1}</span> vs <span class="team-${state.players[b.p2]}">${b.p2}</span> 🏆 <span class="team-${state.players[b.winner]}">${b.winner}</span></li>`});
     html+='</ul>';
-    slides.push({bg:'brown',html});
+    slides.push({color:'brown',image:bgImages.pacal,html});
   }
   if(state.attractions.length>0){
     const now=new Date();
@@ -65,18 +74,19 @@ function render(){
     let html='<h1>Atrações</h1>';
     if(current) html+=`<p>Agora: ${current.name}</p>`;
     if(next){const diff=Math.floor((new Date(next.time)-now)/1000);html+=`<p>Em seguida: ${next.name} (em ${diff}s)</p>`;} 
-    slides.push({bg:'blue',html});
+    slides.push({color:'blue',image:bgImages.attractions,html});
   }
   const scoreEntries=Object.entries(state.scores).sort((a,b)=>b[1]-a[1]);
   let html='<h1>Placar</h1><ul>';
   scoreEntries.forEach(([team,score],i)=>{html+=`<li>${state.teamNames[team]} - ${score} ${i==0?'🏆':''}</li>`});
   html+='</ul>';
-  slides.push({bg:'black',html});
+  slides.push({color:'black',image:bgImages.score,html});
 
   slides.forEach((s,i)=>{
     const div=document.createElement('div');
     div.className='slide';
-    div.style.background=s.bg;
+    if(s.color) div.style.backgroundColor=s.color;
+    if(s.image) div.style.backgroundImage=`url('${s.image}')`;
     div.innerHTML=s.html;
     slidesEl.appendChild(div);
   });


### PR DESCRIPTION
## Summary
- allow slides to use background images
- document background image usage in README
- include `public/backgrounds` directory for user images

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849c194e85c8331961fba7d17c32665