### PR TITLE
Fix bull deletion route and clean comments

### DIFF
--- a/public/beer.html
+++ b/public/beer.html
@@ -16,7 +16,6 @@ label{display:block;margin-top:10px;}
 <label>Jogador2 (Time Amarelo) <input id="beerYellowP2" list="playersYellow"></label>
 <label>Vencedor <select id="beerWin"></select></label>
 <button onclick="addBeer()">Registrar</button>
-codex/adicionar-histórico-de-registros-editável
 <datalist id="players"></datalist>
 <h2>Histórico</h2>
 <table id="hist"></table>
@@ -64,7 +63,6 @@ async function ensurePlayer(name){
 }
 async function addBeer(){for(const n of [beerT1P1.value,beerT1P2.value,beerT2P1.value,beerT2P2.value,beerWin.value]) await ensurePlayer(n);post('/api/beer',{team1:[beerT1P1.value,beerT1P2.value],team2:[beerT2P1.value,beerT2P2.value],winner:beerWin.value});beerT1P1.value='';beerT1P2.value='';beerT2P1.value='';beerT2P2.value='';beerWin.value='';}
 const playersElem=document.getElementById('players');
-codex/adicionar-histórico-de-registros-editável
 function loadHistory(){
   fetch('/api/state').then(r=>r.json()).then(s=>{
     const rows=s.beerPongs.map((b,i)=>`<tr>

--- a/public/bull.html
+++ b/public/bull.html
@@ -44,7 +44,6 @@ async function ensurePlayer(name){
 }
 async function addBull(){await ensurePlayer(bullPlayer.value);post('/api/bull',{name:bullPlayer.value,time:bullTime.value});bullPlayer.value='';bullTime.value='';}
 const playersElem=document.getElementById('players');
- codex/adicionar-histórico-de-registros-editável
 function loadHistory(){
   fetch('/api/state').then(r=>r.json()).then(s=>{
     const rows=s.bullTimes.map((b,i)=>`<tr>

--- a/src/server.js
+++ b/src/server.js
@@ -110,7 +110,6 @@ app.post('/api/bull', (req,res)=>{
   res.end();
 });
 
- codex/adicionar-histórico-de-registros-editável
 app.put('/api/bull/:index', (req,res)=>{
   const idx = parseInt(req.params.index,10);
   if(Number.isNaN(idx) || !data.bullTimes[idx]) return res.status(404).end();
@@ -123,6 +122,8 @@ app.delete('/api/bull/:index', (req,res)=>{
   const idx = parseInt(req.params.index,10);
   if(Number.isNaN(idx) || !data.bullTimes[idx]) return res.status(404).end();
   data.bullTimes.splice(idx,1);
+  res.end();
+});
 
 app.post('/api/bull/finish', (req,res)=>{
   data.bullFinished = true;
@@ -132,7 +133,6 @@ app.post('/api/bull/finish', (req,res)=>{
 app.post('/api/bull/new', (req,res)=>{
   data.bullTimes = [];
   data.bullFinished = false;
-main
   res.end();
 });
 


### PR DESCRIPTION
## Summary
- remove stale `codex/adicionar-histórico-de-registros-editável` comments
- fix `/api/bull/:index` route and remove stray `main`
- keep Node syntax clean

## Testing
- `node -c src/server.js`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ff2af4048331b3ba5817c0dc70cf