### PR TITLE
Fix attraction times parsed as UTC

### DIFF
--- a/public/lineup.html
+++ b/public/lineup.html
@@ -31,7 +31,7 @@ async function load(){
     const tr=document.createElement('tr');
     tr.dataset.index=idx;
     tr.innerHTML=`<td><input data-field="name" value="${a.name}" disabled></td>`+
-      `<td><input data-field="time" type="datetime-local" value="${new Date(a.time).toISOString().slice(0,16)}" disabled></td>`+
+      `<td><input data-field="time" type="datetime-local" value="${a.time}" disabled></td>`+
       `<td><button data-action="edit">Editar</button>`+
       `<button data-action="save" style="display:none">Salvar</button>`+
       `<button data-action="delete">Excluir</button></td>`;

--- a/src/server.js
+++ b/src/server.js
@@ -218,8 +218,7 @@ app.delete('/api/bingo', (req,res)=>{
 
 app.post('/api/attraction', (req,res)=>{
   const { time, name } = req.body;
-  const iso = new Date(time).toISOString();
-  data.attractions.push({ time: iso, name });
+  data.attractions.push({ time, name });
   res.end();
 });
 
@@ -231,8 +230,7 @@ app.put('/api/attraction/:index', (req,res)=>{
   const idx = parseInt(req.params.index,10);
   if (Number.isNaN(idx) || !data.attractions[idx]) return res.status(404).end();
   const { time, name } = req.body;
-  const iso = new Date(time).toISOString();
-  data.attractions[idx] = { time: iso, name };
+  data.attractions[idx] = { time, name };
   res.end();
 });
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -30,7 +30,7 @@ describe('Express API', () => {
       .get('/api/attractions')
       .expect(200);
 
-    expect(list.body[0]).toEqual({ name: 'Show 2', time: '2023-01-01T11:00:00.000Z' });
+    expect(list.body[0]).toEqual({ name: 'Show 2', time: '2023-01-01T11:00' });
 
     await request(app)
       .delete('/api/attraction/0')


### PR DESCRIPTION
## Summary
- store attraction time exactly as provided instead of converting to UTC
- display stored attraction time directly in lineup editor
- update tests for new time format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a0459afc483318ab6f34a25ba8182