### PR TITLE
Add persistent data storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ Then access `http://localhost:3000/` for slides,
 `http://localhost:3000/lineup.html` for the lineup editor,
 `http://localhost:3000/reset.html` to reset all data.
 
+### Data persistence
+
+All scoreboard information is automatically saved to a `data.json` file in the
+project root. The server loads this file on startup and writes changes back to
+it whenever data is modified, so results persist across restarts. If the file
+does not exist it will be created the first time the server runs.
+
 ### Background images
 
 Add your desired slide backgrounds in the `public/backgrounds` directory using the filenames listed above. When present, they will automatically be used in the slideshow.

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,5 +1,21 @@
 const request = require('supertest');
+const fs = require('fs');
+const path = require('path');
+
+process.env.DATA_FILE = path.join(__dirname, 'test-data.json');
 const { app } = require('../src/server');
+
+beforeEach(() => {
+  if (fs.existsSync(process.env.DATA_FILE)) {
+    fs.unlinkSync(process.env.DATA_FILE);
+  }
+});
+
+afterAll(() => {
+  if (fs.existsSync(process.env.DATA_FILE)) {
+    fs.unlinkSync(process.env.DATA_FILE);
+  }
+});
 
 describe('Express API', () => {
   it('registers a player and returns state', async () => {


### PR DESCRIPTION
## Summary
- support configurable `DATA_FILE` in the server and add load/save helpers
- automatically save all data changes
- update tests to use an isolated json file
- document persistent storage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a0b063bb083319d93c5638bc166ff