### PR TITLE
Support configurable data directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules
 
+data/
+
 # Logs
 npm-debug.log*
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ The provided Dockerfile uses the official `node:20` image as its base. You can s
 ### Run
 
 ```bash
-docker run -p 3000:3000 arraia
+# persist data in /path/on/host
+docker run -p 3000:3000 -v /path/on/host:/app/data arraia
 ```
 
 Then access `http://localhost:3000/` for slides,
@@ -60,10 +61,16 @@ Then access `http://localhost:3000/` for slides,
 
 ### Data persistence
 
-All scoreboard information is automatically saved to a `data.json` file in the
-project root. The server loads this file on startup and writes changes back to
-it whenever data is modified, so results persist across restarts. If the file
-does not exist it will be created the first time the server runs.
+All scoreboard information is automatically saved to a `data.json` file inside
+the `data` directory. Set the `DATA_DIR` environment variable to point
+elsewhere if desired. When using Docker, mount a host folder at
+`/app/data` so the file is preserved across container restarts:
+
+```bash
+docker run -p 3000:3000 -v /path/on/host:/app/data arraia
+```
+
+If the file does not exist it will be created the first time the server runs.
 
 ### Background images
 

--- a/src/server.js
+++ b/src/server.js
@@ -10,7 +10,7 @@ const port = process.env.PORT || 3000;
 app.use(bodyParser.json());
 app.use(express.static(path.join(__dirname, '..', 'public')));
 
-const DATA_FILE = process.env.DATA_FILE || path.join(__dirname, '..', 'data.json');
+const DATA_FILE = process.env.DATA_FILE || path.join(process.env.DATA_DIR || path.join(__dirname, '..', 'data'), 'data.json');
 
 const defaultData = {
   players: {}, // name -> team
@@ -53,6 +53,10 @@ function loadData(){
 
 function saveData(){
   try{
+    const dir = path.dirname(DATA_FILE);
+    if(!fs.existsSync(dir)){
+      fs.mkdirSync(dir, { recursive: true });
+    }
     fs.writeFileSync(DATA_FILE, JSON.stringify(data, null, 2));
   }catch(e){
     console.error('Failed to save data file:', e);


### PR DESCRIPTION
## Summary
- support storing `data.json` in a dedicated data directory
- create directory automatically when saving
- document `DATA_DIR` and volume mapping
- ignore the data directory

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a41468b708331ad2dae5b205d10cd