### PR TITLE
Fix top touro slide alignment

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -33,7 +33,7 @@ body,html{margin:0;padding:0;height:100%;width:100%;font-family:sans-serif;color
 .bull-slide{font-family:'Comic Sans MS','Comic Sans',cursive;font-weight:bold;}
 .bull-title{font-size:72px;}
 .bull-table{margin:auto;font-size:64px;border-collapse:collapse;}
-.bull-table td{padding:10px 20px;}
+.bull-table td{padding:10px 20px;text-align:left;}
 
 </style>
 </head>


### PR DESCRIPTION
## Summary
- left align text on the Top Touro slide table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a4665e288833198668a21d75c21e8