### PR TITLE
Block same team duels

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -65,6 +65,12 @@ function saveData(){
 
 loadData();
 
+function sameTeam(...players){
+  const teams = players.map(p => data.players[p]).filter(Boolean);
+  if(teams.length < players.length) return false;
+  return new Set(teams).size === 1;
+}
+
 function computeScores() {
   data.scores = {blue:0, yellow:0};
   if (data.bullFinished && data.bullTimes.length > 0) {
@@ -176,6 +182,7 @@ app.post('/api/bull/new', (req,res)=>{
 
 app.post('/api/cotton', (req,res)=>{
   const {p1,p2,winner,time} = req.body;
+  if(!p1 || !p2 || p1===p2 || sameTeam(p1,p2)) return res.status(400).end();
   data.cottonWars.push({
     p1,
     p2,
@@ -190,6 +197,7 @@ app.put('/api/cotton/:index', (req,res)=>{
   const idx = parseInt(req.params.index,10);
   if(Number.isNaN(idx) || !data.cottonWars[idx]) return res.status(404).end();
   const {p1,p2,winner,time} = req.body;
+  if(!p1 || !p2 || p1===p2 || sameTeam(p1,p2)) return res.status(400).end();
   const existing = data.cottonWars[idx];
   data.cottonWars[idx] = {
     p1,
@@ -211,6 +219,9 @@ app.delete('/api/cotton/:index', (req,res)=>{
 
 app.post('/api/beer', (req,res)=>{
   const {team1,team2,winner} = req.body;
+  if(!team1 || !team2 || team1.length!==2 || team2.length!==2) return res.status(400).end();
+  if(team1[0]===team1[1] || team2[0]===team2[1]) return res.status(400).end();
+  if(!sameTeam(team1[0],team1[1]) || !sameTeam(team2[0],team2[1]) || sameTeam(team1[0],team2[0])) return res.status(400).end();
   data.beerPongs.push({team1,team2,winner});
   saveData();
   res.end();
@@ -220,6 +231,9 @@ app.put('/api/beer/:index', (req,res)=>{
   const idx = parseInt(req.params.index,10);
   if(Number.isNaN(idx) || !data.beerPongs[idx]) return res.status(404).end();
   const {team1,team2,winner} = req.body;
+  if(!team1 || !team2 || team1.length!==2 || team2.length!==2) return res.status(400).end();
+  if(team1[0]===team1[1] || team2[0]===team2[1]) return res.status(400).end();
+  if(!sameTeam(team1[0],team1[1]) || !sameTeam(team2[0],team2[1]) || sameTeam(team1[0],team2[0])) return res.status(400).end();
   data.beerPongs[idx] = {team1,team2,winner};
   saveData();
   res.end();
@@ -235,6 +249,7 @@ app.delete('/api/beer/:index', (req,res)=>{
 
 app.post('/api/pacal', (req,res)=>{
   const {p1,p2,winner} = req.body;
+  if(!p1 || !p2 || p1===p2 || sameTeam(p1,p2)) return res.status(400).end();
   data.pacalWars.push({p1,p2,winner});
   saveData();
   res.end();
@@ -244,6 +259,7 @@ app.put('/api/pacal/:index', (req,res)=>{
   const idx = parseInt(req.params.index,10);
   if(Number.isNaN(idx) || !data.pacalWars[idx]) return res.status(404).end();
   const {p1,p2,winner} = req.body;
+  if(!p1 || !p2 || p1===p2 || sameTeam(p1,p2)) return res.status(400).end();
   data.pacalWars[idx] = {p1,p2,winner};
   saveData();
   res.end();

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -104,4 +104,36 @@ describe('Express API', () => {
     res = await request(app).get('/api/state').expect(200);
     expect(res.body.scores.blue).toBe(res.body.points.bullFirst);
   });
+
+  it('rejects cotton wars between players of the same team', async () => {
+    await request(app).post('/api/player').send({ name: 'Alice', team: 'blue' }).expect(200);
+    await request(app).post('/api/player').send({ name: 'Bob', team: 'blue' }).expect(200);
+
+    await request(app)
+      .post('/api/cotton')
+      .send({ p1: 'Alice', p2: 'Bob', winner: 'Alice' })
+      .expect(400);
+  });
+
+  it('rejects beer pong matches between the same team', async () => {
+    await request(app).post('/api/player').send({ name: 'A1', team: 'blue' }).expect(200);
+    await request(app).post('/api/player').send({ name: 'A2', team: 'blue' }).expect(200);
+    await request(app).post('/api/player').send({ name: 'B1', team: 'blue' }).expect(200);
+    await request(app).post('/api/player').send({ name: 'B2', team: 'blue' }).expect(200);
+
+    await request(app)
+      .post('/api/beer')
+      .send({ team1: ['A1','A2'], team2: ['B1','B2'], winner: 'blue' })
+      .expect(400);
+  });
+
+  it('rejects pacal duels between players of the same team', async () => {
+    await request(app).post('/api/player').send({ name: 'P1', team: 'yellow' }).expect(200);
+    await request(app).post('/api/player').send({ name: 'P2', team: 'yellow' }).expect(200);
+
+    await request(app)
+      .post('/api/pacal')
+      .send({ p1: 'P1', p2: 'P2', winner: 'P1' })
+      .expect(400);
+  });
 });


### PR DESCRIPTION
## Summary
- block same-team matchups on cotonete, beer pong and pacal
- add tests to ensure same-team games are rejected

## Testing
- `npm install --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684a495229908331ac1070baed95b516