### PR TITLE
Fix player rename propagation

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -130,6 +130,29 @@ app.put('/api/player/:name', (req,res)=>{
   if(name !== oldName){
     data.players[name] = data.players[oldName];
     delete data.players[oldName];
+
+    data.bullTimes.forEach(r => {
+      if(r.name === oldName) r.name = name;
+    });
+    data.cottonWars.forEach(r => {
+      if(r.p1 === oldName) r.p1 = name;
+      if(r.p2 === oldName) r.p2 = name;
+      if(r.winner === oldName) r.winner = name;
+    });
+    data.beerPongs.forEach(b => {
+      b.team1 = b.team1.map(p => p === oldName ? name : p);
+      b.team2 = b.team2.map(p => p === oldName ? name : p);
+    });
+    data.pacalWars.forEach(r => {
+      if(r.p1 === oldName) r.p1 = name;
+      if(r.p2 === oldName) r.p2 = name;
+      if(r.winner === oldName) r.winner = name;
+    });
+    if (data.bingoWinners) {
+      if(data.bingoWinners.first === oldName) data.bingoWinners.first = name;
+      if(data.bingoWinners.second === oldName) data.bingoWinners.second = name;
+      if(data.bingoWinners.third === oldName) data.bingoWinners.third = name;
+    }
   }
   if(team) data.players[name] = team;
   saveData();

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -136,4 +136,24 @@ describe('Express API', () => {
       .send({ p1: 'P1', p2: 'P2', winner: 'P1' })
       .expect(400);
   });
+
+  it('renames a player and updates all event references', async () => {
+    await request(app).post('/api/reset').expect(200);
+    await request(app).post('/api/player').send({ name: 'Old', team: 'blue' }).expect(200);
+    await request(app).post('/api/player').send({ name: 'Opp', team: 'yellow' }).expect(200);
+
+    await request(app)
+      .post('/api/cotton')
+      .send({ p1: 'Old', p2: 'Opp', winner: 'Old' })
+      .expect(200);
+
+    await request(app).put('/api/player/Old').send({ name: 'New' }).expect(200);
+
+    const res = await request(app).get('/api/state').expect(200);
+    expect(res.body.players.Old).toBeUndefined();
+    expect(res.body.players.New).toBe('blue');
+    expect(res.body.cottonWars[0].p1).toBe('New');
+    expect(res.body.cottonWars[0].winner).toBe('New');
+    expect(res.body.scores.blue).toBe(res.body.points.cottonWin);
+  });
 });


### PR DESCRIPTION
## Summary
- update PUT /api/player/:name to rename across all events
- test renaming a player updates events and scores

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b73cb071c8331a389be7c5c65c344