### PR TITLE
Add validation for bull times

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -145,7 +145,9 @@ app.delete('/api/player/:name', (req,res)=>{
 
 app.post('/api/bull', (req,res)=>{
   const {name,time} = req.body;
-  data.bullTimes.push({name,time:parseFloat(time)});
+  const t = parseFloat(time);
+  if(!Number.isFinite(t)) return res.status(400).end();
+  data.bullTimes.push({name,time:t});
   saveData();
   res.end();
 });
@@ -154,7 +156,9 @@ app.put('/api/bull/:index', (req,res)=>{
   const idx = parseInt(req.params.index,10);
   if(Number.isNaN(idx) || !data.bullTimes[idx]) return res.status(404).end();
   const {name,time} = req.body;
-  data.bullTimes[idx] = {name,time:parseFloat(time)};
+  const t = parseFloat(time);
+  if(!Number.isFinite(t)) return res.status(400).end();
+  data.bullTimes[idx] = {name,time:t};
   saveData();
   res.end();
 });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -136,4 +136,23 @@ describe('Express API', () => {
       .send({ p1: 'P1', p2: 'P2', winner: 'P1' })
       .expect(400);
   });
+
+  it('rejects invalid bull times', async () => {
+    await request(app).post('/api/player').send({ name: 'Alice', team: 'blue' }).expect(200);
+
+    await request(app)
+      .post('/api/bull')
+      .send({ name: 'Alice', time: 'Infinity' })
+      .expect(400);
+
+    await request(app)
+      .post('/api/bull')
+      .send({ name: 'Alice', time: '5' })
+      .expect(200);
+
+    await request(app)
+      .put('/api/bull/0')
+      .send({ name: 'Alice', time: 'NaN' })
+      .expect(400);
+  });
 });


### PR DESCRIPTION
## Summary
- validate that bull times are finite numbers
- test that invalid bull times are rejected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b73cee478833188f63a51f7d532ee