### PR TITLE
Fix test case closure

### DIFF
--- a/test/server.test.js
+++ b/test/server.test.js
@@ -156,6 +156,7 @@ describe('Express API', () => {
     .send({ name: 'Alice', time: 'NaN' })
     .expect(400);
   });
+  });
 
   it('renames a player and updates all event references', async () => {
     await request(app).post('/api/reset').expect(200);


### PR DESCRIPTION
## Summary
- close a Jest test case in `server.test.js`
- run npm test

## Testing
- `npm test` *(fails: Jest SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_684b8f83cec08331b5e424e66835ba63