### PR TITLE
Improve slide compatibility on older browsers

### DIFF
--- a/public/js/slides.js
+++ b/public/js/slides.js
@@ -211,7 +211,26 @@ if (!document.querySelector) {
     render();
   };
   var fetchState = function fetchState() {
-    fetch('/api/state').then(function (r) {
+    var doFetch = window.fetch ? window.fetch : function (url) {
+      return new Promise(function (resolve, reject) {
+        try {
+          var xhr = new XMLHttpRequest();
+          xhr.open('GET', url);
+          xhr.onload = function () {
+            resolve({
+              json: function json() {
+                return Promise.resolve(JSON.parse(xhr.responseText));
+              }
+            });
+          };
+          xhr.onerror = reject;
+          xhr.send();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    };
+    doFetch('/api/state').then(function (r) {
       return r.json();
     }).then(updateAndRender)["catch"](function (err) {
       return console.error('Polling failed', err);

--- a/src/js/slides.js
+++ b/src/js/slides.js
@@ -140,10 +140,23 @@ function updateAndRender(data){
 }
 
 function fetchState(){
-  fetch('/api/state')
-    .then(r=>r.json())
+  var doFetch = window.fetch ? window.fetch : function(url){
+    return new Promise(function(resolve,reject){
+      try{
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', url);
+        xhr.onload = function(){
+          resolve({ json: function(){ return Promise.resolve(JSON.parse(xhr.responseText)); } });
+        };
+        xhr.onerror = reject;
+        xhr.send();
+      }catch(e){reject(e);}
+    });
+  };
+  doFetch('/api/state')
+    .then(function(r){ return r.json(); })
     .then(updateAndRender)
-    .catch(err=>console.error('Polling failed',err));
+    .catch(function(err){ return console.error('Polling failed', err); });
 }
 
 function startPolling(){

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -156,7 +156,6 @@ describe('Express API', () => {
     .send({ name: 'Alice', time: 'NaN' })
     .expect(400);
   });
-  });
 
   it('renames a player and updates all event references', async () => {
     await request(app).post('/api/reset').expect(200);


### PR DESCRIPTION
## Summary
- fix syntax error in Jest tests
- add XHR fallback in `slides.js` when `fetch` is unavailable

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b9f7cd31883318f0ebcfa68c676a5