### PR TITLE
Simplify client to use old‑school polling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "body-parser": "^2.2.0",
-        "express": "^5.1.0",
-        "ws": "^8.18.2"
+        "express": "^5.1.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.24.0",
@@ -7012,27 +7011,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   "type": "commonjs",
   "dependencies": {
     "body-parser": "^2.2.0",
-    "express": "^5.1.0",
-    "ws": "^8.18.2"
+    "express": "^5.1.0"
   },
   "devDependencies": {
     "jest": "^30.0.0",

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const bodyParser = require('body-parser');
-const WebSocket = require('ws');
 const path = require('path');
 const fs = require('fs');
 
@@ -375,19 +374,7 @@ function startServer() {
   const server = app.listen(port, () => {
     console.log('Server listening on', port);
   });
-
-  const wss = new WebSocket.Server({ server });
-  wss.on('connection', ws => {
-    computeScores();
-    ws.send(JSON.stringify(data));
-  });
-  function broadcast() {
-    computeScores();
-    const msg = JSON.stringify(data);
-    wss.clients.forEach(c => c.readyState === WebSocket.OPEN && c.send(msg));
-  }
-  setInterval(broadcast, 5000);
-  return { server, wss };
+  return { server };
 }
 
 if (require.main === module) {


### PR DESCRIPTION
## Summary
- drop `ws` dependency and websocket server code
- replace modern fetch/websocket logic with simple XMLHttpRequest polling
- rebuild slides script for public assets

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684cc4aa55048331a68c8b42dd05da26