### PR TITLE
Adjust left margin for cotton and pacal slides

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,13 +18,13 @@ body,html{margin:0;padding:0;height:100%;width:100%;font-family:sans-serif;color
 .attractions-next{font-size:80px;}
 .clock{font-size:60px;}
 /* Estilos para slide de guerra de cotonete */
-.cotton-slide{font-family:'Comic Sans MS','Comic Sans',cursive;font-weight:bold;}
+.cotton-slide{font-family:'Comic Sans MS','Comic Sans',cursive;font-weight:bold;padding-left:40px;}
 .cotton-slide h1{font-size:72px;margin-top:0;}
 .cotton-row{font-size:48px;display:flex;align-items:baseline;padding:5px 20px;}
 .cotton-wrapper{column-count:2;text-align:left;}
 .cotton-time{font-size:0.7em;margin-left:8px;}
 /* Estilos para slide de pacal */
-.pacal-slide{font-family:'Comic Sans MS','Comic Sans',cursive;font-weight:bold;}
+.pacal-slide{font-family:'Comic Sans MS','Comic Sans',cursive;font-weight:bold;padding-left:40px;}
 .pacal-slide h1{font-size:72px;margin-top:0;}
 .pacal-row{font-size:48px;display:flex;align-items:baseline;padding:5px 20px;}
 .pacal-wrapper{column-count:2;text-align:left;}


### PR DESCRIPTION
## Summary
- add extra left padding to the cotton and pacal slide containers so text isn't flush against the screen edge

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ceb57558c8331bb77bb918ec49ab8