### PR TITLE
Update beer pong slide display

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -45,8 +45,8 @@ body,html{margin:0;padding:0;height:100%;width:100%;font-family:sans-serif;color
 /* Estilos para slide de Beer Pong */
 .beer-slide{font-family:'Comic Sans MS','Comic Sans',cursive;font-weight:bold;}
 .beer-title{font-size:96px;}
-.beer-table{margin:auto;font-size:64px;border-collapse:collapse;}
-.beer-table td{padding:10px 20px;}
+.beer-wrapper{column-count:2;text-align:left;}
+.beer-row{font-size:48px;display:flex;align-items:baseline;padding:5px 20px;}
 
 /* Estilos para slide de placar */
 .score-slide{font-family:'Comic Sans MS','Comic Sans',cursive;font-weight:bold;}

--- a/public/js/slides.js
+++ b/public/js/slides.js
@@ -108,14 +108,16 @@ if (!document.querySelector) {
       });
     }
     if (state.beerPongs.length > 0) {
-      var _html4 = '<div class="beer-slide">';
-      _html4 += '<div class="beer-title">🍺 Beer Pong 🍺</div>';
-      _html4 += '<table class="beer-table">';
-      state.beerPongs.slice(-5).forEach(function (b) {
-        _html4 += "<tr><td><span class=\"team-".concat(state.players[b.team1[0]], "\">").concat(b.team1[0], "</span></td><td><span class=\"team-").concat(state.players[b.team2[0]], "\">").concat(b.team2[0], "</span></td><td rowspan=\"2\">\uD83C\uDFC6 <span class=\"team-").concat(b.winner, "\">").concat(state.teamNames[b.winner], "</span></td></tr>");
-        _html4 += "<tr><td><span class=\"team-".concat(state.players[b.team1[1]], "\">").concat(b.team1[1], "</span></td><td><span class=\"team-").concat(state.players[b.team2[1]], "\">").concat(b.team2[1], "</span></td></tr>");
+      var _recent = state.beerPongs.slice(-6).reverse();
+      var _html4 = '<div class="beer-slide"><h1 class="beer-title">🍺 Beer Pong 🍺</h1><div class="beer-wrapper">';
+      _recent.forEach(function (b) {
+        var team1Color = state.players[b.team1[0]];
+        var team2Color = state.players[b.team2[0]];
+        var trophy1 = team1Color === b.winner ? ' 🏆' : '';
+        var trophy2 = team2Color === b.winner ? ' 🏆' : '';
+        _html4 += "<div class=\"beer-row\"><span class=\"team-".concat(team1Color, "\">").concat(b.team1[0], "</span> & <span class=\"team-").concat(team1Color, "\">").concat(b.team1[1], "</span>").concat(trophy1, " vs <span class=\"team-").concat(team2Color, "\">").concat(b.team2[0], "</span> & <span class=\"team-").concat(team2Color, "\">").concat(b.team2[1], "</span>").concat(trophy2, "</div>");
       });
-      _html4 += '</table></div>';
+      _html4 += '</div></div>';
       slides.push({
         color: 'orange',
         image: bgImages.beer,
@@ -124,9 +126,9 @@ if (!document.querySelector) {
     }
     if (state.pacalWars.length > 0) {
       var _pts2 = state.points.pacalWin || 0;
-      var _recent = state.pacalWars.slice().reverse();
+      var _recent2 = state.pacalWars.slice().reverse();
       var _html5 = '<div class="pacal-slide"><h1>Pacal 🎯</h1><div class="pacal-wrapper">';
-      _recent.forEach(function (b) {
+      _recent2.forEach(function (b) {
         var trophy1 = b.winner === b.p1 ? '🏆' : '';
         var trophy2 = b.winner === b.p2 ? '🏆' : '';
         _html5 += "<div class=\"pacal-row\"><span class=\"team-".concat(state.players[b.p1], "\">").concat(b.p1).concat(trophy1, "</span> vs <span class=\"team-").concat(state.players[b.p2], "\">").concat(b.p2).concat(trophy2, "</span> (+").concat(_pts2, ")</div>");

--- a/src/js/slides.js
+++ b/src/js/slides.js
@@ -98,14 +98,16 @@ function render(){
     slides.push({color:'purple',image:bgImages.bingo,html});
   }
   if(state.beerPongs.length>0){
-    let html='<div class="beer-slide">';
-    html+='<div class="beer-title">🍺 Beer Pong 🍺</div>';
-    html+='<table class="beer-table">';
-    state.beerPongs.slice(-5).forEach(b=>{
-      html+=`<tr><td><span class="team-${state.players[b.team1[0]]}">${b.team1[0]}</span></td><td><span class="team-${state.players[b.team2[0]]}">${b.team2[0]}</span></td><td rowspan="2">🏆 <span class="team-${b.winner}">${state.teamNames[b.winner]}</span></td></tr>`;
-      html+=`<tr><td><span class="team-${state.players[b.team1[1]]}">${b.team1[1]}</span></td><td><span class="team-${state.players[b.team2[1]]}">${b.team2[1]}</span></td></tr>`;
+    const recent = state.beerPongs.slice(-6).reverse();
+    let html='<div class="beer-slide"><h1 class="beer-title">🍺 Beer Pong 🍺</h1><div class="beer-wrapper">';
+    recent.forEach(b=>{
+      const team1Color=state.players[b.team1[0]];
+      const team2Color=state.players[b.team2[0]];
+      const trophy1=team1Color===b.winner?' 🏆':'';
+      const trophy2=team2Color===b.winner?' 🏆':'';
+      html+=`<div class="beer-row"><span class="team-${team1Color}">${b.team1[0]}</span> & <span class="team-${team1Color}">${b.team1[1]}</span>${trophy1} vs <span class="team-${team2Color}">${b.team2[0]}</span> & <span class="team-${team2Color}">${b.team2[1]}</span>${trophy2}</div>`;
     });
-    html+='</table></div>';
+    html+='</div></div>';
     slides.push({color:'orange',image:bgImages.beer,html});
   }
   if(state.pacalWars.length>0){


### PR DESCRIPTION
## Summary
- adjust Beer Pong slide to show recent six games in two columns
- remove team name and display trophy next to winner

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684cebd649d883319f87fd337224adb0