### PR TITLE
Improve scoreboard slide styling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -49,14 +49,14 @@ body,html{margin:0;padding:0;height:100%;width:100%;font-family:sans-serif;color
 .beer-table td{padding:10px 20px;}
 
 /* Estilos para slide de placar */
-.score-slide{font-family:'Comic Sans MS','Comic Sans',cursive;font-weight:bold;}
+.score-slide{font-family:'Comic Sans MS','Comic Sans',cursive;font-weight:bold;display:flex;flex-direction:column;justify-content:center;height:100%;}
 .score-chart{width:90%;margin:0 auto;margin-top:40px;}
 .score-row{display:flex;align-items:center;margin:20px 0;height:100px;font-size:64px;}
-.team-label{text-align:right;width:25%;padding-right:20px;}
-.score-bar{flex-grow:1;height:100%;border-radius:50px;display:flex;align-items:center;justify-content:flex-end;padding-right:40px;color:black;font-weight:bold;box-shadow:0 4px 10px rgba(0,0,0,0.3);}
-.score-bar.team-blue{background-color:rgba(0,0,255,0.8);}
-.score-bar.team-yellow{background-color:rgba(255,215,0,0.8);}
-.score-value{font-size:64px;}
+.score-bar{flex-grow:1;height:100%;border-radius:50px;display:flex;align-items:center;justify-content:space-between;padding:0 40px;font-weight:bold;color:black;box-shadow:0 4px 10px rgba(0,0,0,0.3);}
+.score-bar.team-blue{background-color:rgba(0,0,255,0.8);color:white;}
+.score-bar.team-yellow{background-color:rgba(255,215,0,0.8);color:black;}
+.score-name{white-space:nowrap;}
+.score-value{font-size:64px;white-space:nowrap;}
 
 </style>
 </head>

--- a/public/js/slides.js
+++ b/public/js/slides.js
@@ -173,13 +173,13 @@ if (!document.querySelector) {
     var maxScore = Math.max.apply(Math, _toConsumableArray(scoreEntries.map(function (s) {
       return s[1];
     })).concat([1]));
-    var html = '<div class="score-slide"><h1>Placar</h1><div class="score-chart">';
+    var html = '<div class="score-slide"><h1>Placar 🎉</h1><div class="score-chart">';
     scoreEntries.forEach(function (_ref, i) {
       var _ref2 = _slicedToArray(_ref, 2),
         team = _ref2[0],
         score = _ref2[1];
       var pct = Math.round(score / maxScore * 100);
-      html += "<div class=\"score-row\"><div class=\"team-label\">".concat(state.teamNames[team], "</div><div class=\"score-bar team-").concat(team, "\" style=\"width:").concat(pct, "%\"><span class=\"score-value\">").concat(score).concat(i == 0 ? ' 🏆' : '', "</span></div></div>");
+      html += "<div class=\"score-row\"><div class=\"score-bar team-".concat(team, "\" style=\"width:").concat(pct, "%\"><span class=\"score-name\">").concat(state.teamNames[team], "</span><span class=\"score-value\">").concat(score).concat(i == 0 ? ' 🏆' : '', "</span></div></div>");
     });
     html += '</div></div>';
     slides.push({

--- a/src/js/slides.js
+++ b/src/js/slides.js
@@ -141,10 +141,10 @@ function render(){
   }
   const scoreEntries=Object.entries(state.scores).sort((a,b)=>b[1]-a[1]);
   const maxScore=Math.max(...scoreEntries.map(s=>s[1]),1);
-  let html='<div class="score-slide"><h1>Placar</h1><div class="score-chart">';
+  let html='<div class="score-slide"><h1>Placar 🎉</h1><div class="score-chart">';
   scoreEntries.forEach(([team,score],i)=>{
     const pct=Math.round(score/maxScore*100);
-    html+=`<div class="score-row"><div class="team-label">${state.teamNames[team]}</div><div class="score-bar team-${team}" style="width:${pct}%"><span class="score-value">${score}${i==0?' 🏆':''}</span></div></div>`;
+    html+=`<div class="score-row"><div class="score-bar team-${team}" style="width:${pct}%"><span class="score-name">${state.teamNames[team]}</span><span class="score-value">${score}${i==0?' 🏆':''}</span></div></div>`;
   });
   html+='</div></div>';
   slides.push({color:'black',image:bgImages.score,html});


### PR DESCRIPTION
## Summary
- update scoreboard slide HTML to place team name and score inside the bar
- vertically center scoreboard slide and adjust colors
- rebuild frontend assets

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ced9e93d88331a9457e099c62e246