### PR TITLE
Add mobile view

### DIFF
--- a/public/js/mobile.js
+++ b/public/js/mobile.js
@@ -1,0 +1,223 @@
+"use strict";
+
+function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
+function _slicedToArray(r, e) { return _arrayWithHoles(r) || _iterableToArrayLimit(r, e) || _unsupportedIterableToArray(r, e) || _nonIterableRest(); }
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+function _iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t["return"] && (u = t["return"](), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
+function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
+function _toConsumableArray(r) { return _arrayWithoutHoles(r) || _iterableToArray(r) || _unsupportedIterableToArray(r) || _nonIterableSpread(); }
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _iterableToArray(r) { if ("undefined" != typeof Symbol && null != r[Symbol.iterator] || null != r["@@iterator"]) return Array.from(r); }
+function _arrayWithoutHoles(r) { if (Array.isArray(r)) return _arrayLikeToArray(r); }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
+function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
+function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
+function _defineProperty(e, r, t) { return (r = _toPropertyKey(r)) in e ? Object.defineProperty(e, r, { value: t, enumerable: !0, configurable: !0, writable: !0 }) : e[r] = t, e; }
+function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == _typeof(i) ? i : i + ""; }
+function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != _typeof(i)) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
+if (!document.querySelector) {
+  document.body.innerHTML = '<div style="padding:20px;font-family:sans-serif;text-align:center">Seu navegador não suporta os recursos necessários para exibir esta página.</div>';
+  console.warn('Navegador sem suporte: querySelector ausente');
+} else {
+  var render = function render() {
+    container.innerHTML = '';
+    if (state.bullTimes.length > 0) {
+      var keys = ['bullFirst', 'bullSecond', 'bullThird', 'bullFourth', 'bullFifth'];
+      var sorted = _toConsumableArray(state.bullTimes).sort(function (a, b) {
+        return a.time - b.time;
+      }).slice(0, 5);
+      var _card = document.createElement('div');
+      _card.className = 'card bull-card';
+      var _html = '<h2>Top Touro 🐂</h2><ol>';
+      sorted.forEach(function (r, i) {
+        var pts = i < keys.length ? state.points[keys[i]] || 0 : 0;
+        _html += "<li><span class=\"team-".concat(state.players[r.name], "\">").concat(r.name, "</span> - ").concat(r.time, "s (").concat(pts, " pts)").concat(i == 0 ? ' 🏆' : '', "</li>");
+      });
+      _html += '</ol>';
+      _card.innerHTML = _html;
+      container.appendChild(_card);
+    }
+    if (state.cottonWars.length > 0) {
+      var pts = state.points.cottonWin || 0;
+      var recent = state.cottonWars.slice().reverse();
+      var _card2 = document.createElement('div');
+      _card2.className = 'card cotton-card';
+      var _html2 = '<h2>Guerra de Cotonete ⚔️</h2>';
+      _html2 += '<ul>';
+      recent.forEach(function (b) {
+        var trophy1 = b.winner === b.p1 ? '🏆' : '';
+        var trophy2 = b.winner === b.p2 ? '🏆' : '';
+        var time = b.time ? new Date(b.time).toLocaleTimeString('pt-BR', {
+          hour: '2-digit',
+          minute: '2-digit'
+        }) : '';
+        _html2 += "<li><span class=\"team-".concat(state.players[b.p1], "\">").concat(b.p1).concat(trophy1, "</span> vs <span class=\"team-").concat(state.players[b.p2], "\">").concat(b.p2).concat(trophy2, "</span> (+").concat(pts, ") <small>").concat(time, "</small></li>");
+      });
+      _html2 += '</ul>';
+      _card2.innerHTML = _html2;
+      container.appendChild(_card2);
+    }
+    if (state.bingoWinners) {
+      var _card3 = document.createElement('div');
+      _card3.className = 'card bingo-card';
+      var _html3 = '<h2>Bingo 🎉</h2><ol>';
+      var rows = [{
+        name: state.bingoWinners.first,
+        key: 'bingoFirst',
+        trophy: '🏆',
+        pos: '1º'
+      }, {
+        name: state.bingoWinners.second,
+        key: 'bingoSecond',
+        pos: '2º'
+      }, {
+        name: state.bingoWinners.third,
+        key: 'bingoThird',
+        pos: '3º'
+      }];
+      rows.forEach(function (r, i) {
+        var pts = state.points[r.key] || 0;
+        _html3 += "<li>".concat(r.pos, " <span class=\"team-").concat(state.players[r.name], "\">").concat(r.name || '', "</span> (").concat(pts, " pts) ").concat(r.trophy || '', "</li>");
+      });
+      _html3 += '</ol>';
+      _card3.innerHTML = _html3;
+      container.appendChild(_card3);
+    }
+    if (state.beerPongs.length > 0) {
+      var _recent = state.beerPongs.slice().reverse();
+      var _card4 = document.createElement('div');
+      _card4.className = 'card beer-card';
+      var _html4 = '<h2>🍺 Beer Pong 🍺</h2><ul>';
+      _recent.forEach(function (b) {
+        var team1Color = state.players[b.team1[0]];
+        var team2Color = state.players[b.team2[0]];
+        var trophy1 = b.winner === team1Color ? '🏆' : '';
+        var trophy2 = b.winner === team2Color ? '🏆' : '';
+        _html4 += "<li><span class=\"team-".concat(team1Color, "\">").concat(b.team1[0], "</span> & <span class=\"team-").concat(team1Color, "\">").concat(b.team1[1], "</span>").concat(trophy1, " vs <span class=\"team-").concat(team2Color, "\">").concat(b.team2[0], "</span> & <span class=\"team-").concat(team2Color, "\">").concat(b.team2[1], "</span>").concat(trophy2, "</li>");
+      });
+      _html4 += '</ul>';
+      _card4.innerHTML = _html4;
+      container.appendChild(_card4);
+    }
+    if (state.pacalWars.length > 0) {
+      var _pts = state.points.pacalWin || 0;
+      var _recent2 = state.pacalWars.slice().reverse();
+      var _card5 = document.createElement('div');
+      _card5.className = 'card pacal-card';
+      var _html5 = '<h2>Pacal 🎯</h2><ul>';
+      _recent2.forEach(function (b) {
+        var trophy1 = b.winner === b.p1 ? '🏆' : '';
+        var trophy2 = b.winner === b.p2 ? '🏆' : '';
+        _html5 += "<li><span class=\"team-".concat(state.players[b.p1], "\">").concat(b.p1).concat(trophy1, "</span> vs <span class=\"team-").concat(state.players[b.p2], "\">").concat(b.p2).concat(trophy2, "</span> (+").concat(_pts, ")</li>");
+      });
+      _html5 += '</ul>';
+      _card5.innerHTML = _html5;
+      container.appendChild(_card5);
+    }
+    if (state.attractions.length > 0) {
+      var now = new Date();
+      var attractions = _toConsumableArray(state.attractions).sort(function (a, b) {
+        return new Date(a.time) - new Date(b.time);
+      });
+      var current = attractions.filter(function (a) {
+        return new Date(a.time) <= now;
+      }).pop();
+      var next = attractions.find(function (a) {
+        return new Date(a.time) > now;
+      });
+      var _card6 = document.createElement('div');
+      _card6.className = 'card attractions-card';
+      var _html6 = '<h2>Atrações 🎡</h2>';
+      if (current) {
+        _html6 += "<div>Agora: <strong>".concat(current.name, "</strong></div>");
+      }
+      if (next) {
+        var diff = Math.ceil((new Date(next.time) - now) / 60000);
+        _html6 += "<div>Em seguida: ".concat(next.name, " <span class=\"clock\">\uD83D\uDD52 ").concat(diff, " min</span></div>");
+      }
+      _card6.innerHTML = _html6;
+      container.appendChild(_card6);
+    }
+    var scoreEntries = Object.entries(state.scores).sort(function (a, b) {
+      return b[1] - a[1];
+    });
+    var maxScore = Math.max.apply(Math, _toConsumableArray(scoreEntries.map(function (s) {
+      return s[1];
+    })).concat([1]));
+    var card = document.createElement('div');
+    card.className = 'card score-card';
+    var html = '<h2>Placar 🏆</h2>';
+    scoreEntries.forEach(function (_ref, i) {
+      var _ref2 = _slicedToArray(_ref, 2),
+        team = _ref2[0],
+        score = _ref2[1];
+      var pct = Math.round(score / maxScore * 100);
+      html += "<div class=\"score-row\"><div class=\"score-bar team-".concat(team, "\" style=\"width:").concat(pct, "%\">").concat(state.teamNames[team], " - ").concat(score).concat(i == 0 ? ' 🏆' : '', "</div></div>");
+    });
+    card.innerHTML = html;
+    container.appendChild(card);
+  };
+  var _updateAndRender = function updateAndRender(data) {
+    try {
+      var serialized = JSON.stringify(data);
+      if (serialized === _updateAndRender.lastSerialized) return;
+      _updateAndRender.lastSerialized = serialized;
+      state = data;
+      render();
+    } catch (e) {
+      console.error('Erro ao atualizar', e);
+    }
+  };
+  var fetchState = function fetchState() {
+    try {
+      fetch('/api/state').then(function (r) {
+        return r.json();
+      }).then(_updateAndRender)["catch"](function (e) {
+        return console.error('Erro fetch', e);
+      });
+    } catch (e) {
+      console.error('Polling exception', e);
+    }
+  };
+  var startPolling = function startPolling() {
+    clearInterval(pollTimer);
+    fetchState();
+    pollTimer = setInterval(fetchState, 5000);
+  };
+  var container = document.getElementById('cards');
+  var defaultState = {
+    players: {},
+    bullTimes: [],
+    bullFinished: false,
+    cottonWars: [],
+    beerPongs: [],
+    pacalWars: [],
+    bingoWinners: null,
+    attractions: [],
+    teamNames: {
+      blue: 'Azul',
+      yellow: 'Amarelo'
+    },
+    points: {
+      bullFirst: 20,
+      bullSecond: 10,
+      bullThird: 5,
+      bullFourth: 3,
+      bullFifth: 1,
+      cottonWin: 3,
+      beerWin: 3,
+      pacalWin: 3,
+      bingoFirst: 5,
+      bingoSecond: 3,
+      bingoThird: 1
+    },
+    scores: {
+      blue: 0,
+      yellow: 0
+    }
+  };
+  var state = _objectSpread({}, defaultState);
+  var pollTimer;
+  startPolling();
+}

--- a/public/mobile/index.html
+++ b/public/mobile/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Arraiá Mobile</title>
+<style>
+body{margin:0;padding:0;font-family:sans-serif;background:black;color:white;}
+.header-img{display:block;margin:10px auto;max-width:200px;width:80%;}
+.card{border-radius:8px;margin:10px;padding:10px;color:white;}
+.bull-card{background:#330000;}
+.cotton-card{background:#002b00;}
+.beer-card{background:#332200;}
+.pacal-card{background:#220033;}
+.bingo-card{background:#330033;}
+.attractions-card{background:#000033;}
+.score-card{background:#222;}
+.team-blue{color:#5fb4ff;}
+.team-yellow{color:#ffff80;}
+.score-row{margin:5px 0;}
+.score-bar{background:rgba(255,255,255,0.2);border-radius:4px;padding:4px;}
+.score-bar.team-blue{background-color:#1c3c7d;}
+.score-bar.team-yellow{background-color:#7d6a1c;color:black;}
+</style>
+</head>
+<body>
+<img src="../images/admin-header.png" alt="Logo" class="header-img">
+<div id="cards"></div>
+<script src="../js/mobile.js"></script>
+</body>
+</html>

--- a/src/js/mobile.js
+++ b/src/js/mobile.js
@@ -1,0 +1,164 @@
+if(!document.querySelector){
+  document.body.innerHTML='<div style="padding:20px;font-family:sans-serif;text-align:center">Seu navegador não suporta os recursos necessários para exibir esta página.</div>';
+  console.warn('Navegador sem suporte: querySelector ausente');
+}else{
+const container=document.getElementById('cards');
+const defaultState={
+  players:{},
+  bullTimes:[],
+  bullFinished:false,
+  cottonWars:[],
+  beerPongs:[],
+  pacalWars:[],
+  bingoWinners:null,
+  attractions:[],
+  teamNames:{blue:'Azul',yellow:'Amarelo'},
+  points:{
+    bullFirst:20,
+    bullSecond:10,
+    bullThird:5,
+    bullFourth:3,
+    bullFifth:1,
+    cottonWin:3,
+    beerWin:3,
+    pacalWin:3,
+    bingoFirst:5,
+    bingoSecond:3,
+    bingoThird:1
+  },
+  scores:{blue:0,yellow:0},
+};
+let state={...defaultState};
+let pollTimer;
+function render(){
+  container.innerHTML='';
+  if(state.bullTimes.length>0){
+    const keys=['bullFirst','bullSecond','bullThird','bullFourth','bullFifth'];
+    const sorted=[...state.bullTimes].sort((a,b)=>a.time-b.time).slice(0,5);
+    const card=document.createElement('div');
+    card.className='card bull-card';
+    let html='<h2>Top Touro 🐂</h2><ol>';
+    sorted.forEach((r,i)=>{
+      const pts=i<keys.length?state.points[keys[i]]||0:0;
+      html+=`<li><span class="team-${state.players[r.name]}">${r.name}</span> - ${r.time}s (${pts} pts)${i==0?' 🏆':''}</li>`;
+    });
+    html+='</ol>';
+    card.innerHTML=html;
+    container.appendChild(card);
+  }
+  if(state.cottonWars.length>0){
+    const pts=state.points.cottonWin||0;
+    const recent=state.cottonWars.slice().reverse();
+    const card=document.createElement('div');
+    card.className='card cotton-card';
+    let html='<h2>Guerra de Cotonete ⚔️</h2>';
+    html+='<ul>';
+    recent.forEach(b=>{
+      const trophy1=b.winner===b.p1?'🏆':'';
+      const trophy2=b.winner===b.p2?'🏆':'';
+      const time=b.time?new Date(b.time).toLocaleTimeString('pt-BR',{hour:'2-digit',minute:'2-digit'}):'';
+      html+=`<li><span class="team-${state.players[b.p1]}">${b.p1}${trophy1}</span> vs <span class="team-${state.players[b.p2]}">${b.p2}${trophy2}</span> (+${pts}) <small>${time}</small></li>`;
+    });
+    html+='</ul>';
+    card.innerHTML=html;
+    container.appendChild(card);
+  }
+  if(state.bingoWinners){
+    const card=document.createElement('div');
+    card.className='card bingo-card';
+    let html='<h2>Bingo 🎉</h2><ol>';
+    const rows=[
+      {name:state.bingoWinners.first,key:'bingoFirst',trophy:'🏆',pos:'1º'},
+      {name:state.bingoWinners.second,key:'bingoSecond',pos:'2º'},
+      {name:state.bingoWinners.third,key:'bingoThird',pos:'3º'},
+    ];
+    rows.forEach((r,i)=>{
+      const pts=state.points[r.key]||0;
+      html+=`<li>${r.pos} <span class="team-${state.players[r.name]}">${r.name||''}</span> (${pts} pts) ${r.trophy||''}</li>`;
+    });
+    html+='</ol>';
+    card.innerHTML=html;
+    container.appendChild(card);
+  }
+  if(state.beerPongs.length>0){
+    const recent=state.beerPongs.slice().reverse();
+    const card=document.createElement('div');
+    card.className='card beer-card';
+    let html='<h2>🍺 Beer Pong 🍺</h2><ul>';
+    recent.forEach(b=>{
+      const team1Color=state.players[b.team1[0]];
+      const team2Color=state.players[b.team2[0]];
+      const trophy1=b.winner===team1Color?'🏆':'';
+      const trophy2=b.winner===team2Color?'🏆':'';
+      html+=`<li><span class="team-${team1Color}">${b.team1[0]}</span> & <span class="team-${team1Color}">${b.team1[1]}</span>${trophy1} vs <span class="team-${team2Color}">${b.team2[0]}</span> & <span class="team-${team2Color}">${b.team2[1]}</span>${trophy2}</li>`;
+    });
+    html+='</ul>';
+    card.innerHTML=html;
+    container.appendChild(card);
+  }
+  if(state.pacalWars.length>0){
+    const pts=state.points.pacalWin||0;
+    const recent=state.pacalWars.slice().reverse();
+    const card=document.createElement('div');
+    card.className='card pacal-card';
+    let html='<h2>Pacal 🎯</h2><ul>';
+    recent.forEach(b=>{
+      const trophy1=b.winner===b.p1?'🏆':'';
+      const trophy2=b.winner===b.p2?'🏆':'';
+      html+=`<li><span class="team-${state.players[b.p1]}">${b.p1}${trophy1}</span> vs <span class="team-${state.players[b.p2]}">${b.p2}${trophy2}</span> (+${pts})</li>`;
+    });
+    html+='</ul>';
+    card.innerHTML=html;
+    container.appendChild(card);
+  }
+  if(state.attractions.length>0){
+    const now=new Date();
+    const attractions=[...state.attractions].sort((a,b)=>new Date(a.time)-new Date(b.time));
+    const current=attractions.filter(a=>new Date(a.time)<=now).pop();
+    const next=attractions.find(a=> new Date(a.time)>now);
+    const card=document.createElement('div');
+    card.className='card attractions-card';
+    let html='<h2>Atrações 🎡</h2>';
+    if(current){
+      html+=`<div>Agora: <strong>${current.name}</strong></div>`;
+    }
+    if(next){
+      const diff=Math.ceil((new Date(next.time)-now)/60000);
+      html+=`<div>Em seguida: ${next.name} <span class="clock">🕒 ${diff} min</span></div>`;
+    }
+    card.innerHTML=html;
+    container.appendChild(card);
+  }
+  const scoreEntries=Object.entries(state.scores).sort((a,b)=>b[1]-a[1]);
+  const maxScore=Math.max(...scoreEntries.map(s=>s[1]),1);
+  const card=document.createElement('div');
+  card.className='card score-card';
+  let html='<h2>Placar 🏆</h2>';
+  scoreEntries.forEach(([team,score],i)=>{
+    const pct=Math.round(score/maxScore*100);
+    html+=`<div class="score-row"><div class="score-bar team-${team}" style="width:${pct}%">${state.teamNames[team]} - ${score}${i==0?' 🏆':''}</div></div>`;
+  });
+  card.innerHTML=html;
+  container.appendChild(card);
+}
+function updateAndRender(data){
+  try{
+    const serialized=JSON.stringify(data);
+    if(serialized===updateAndRender.lastSerialized) return;
+    updateAndRender.lastSerialized=serialized;
+    state=data;
+    render();
+  }catch(e){console.error('Erro ao atualizar',e);}
+}
+function fetchState(){
+  try{
+    fetch('/api/state').then(r=>r.json()).then(updateAndRender).catch(e=>console.error('Erro fetch',e));
+  }catch(e){console.error('Polling exception',e);}
+}
+function startPolling(){
+  clearInterval(pollTimer);
+  fetchState();
+  pollTimer=setInterval(fetchState,5000);
+}
+startPolling();
+}


### PR DESCRIPTION
## Summary
- add a mobile page showing scoreboard information
- implement supporting JS to fetch state and render cards

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cee9397a483318f75047046f70192