### PR TITLE
Fix bull ranking order

### DIFF
--- a/public/js/mobile.js
+++ b/public/js/mobile.js
@@ -25,7 +25,7 @@ if (!document.querySelector) {
     if (state.bullTimes.length > 0) {
       var keys = ['bullFirst', 'bullSecond', 'bullThird', 'bullFourth', 'bullFifth'];
       var sorted = _toConsumableArray(state.bullTimes).sort(function (a, b) {
-        return a.time - b.time;
+        return b.time - a.time;
       }).slice(0, 5);
       var _card = document.createElement('div');
       _card.className = 'card bull-card';

--- a/public/js/slides.js
+++ b/public/js/slides.js
@@ -27,7 +27,7 @@ if (!document.querySelector) {
     if (state.bullTimes.length > 0) {
       var keys = ['bullFirst', 'bullSecond', 'bullThird', 'bullFourth', 'bullFifth'];
       var sorted = _toConsumableArray(state.bullTimes).sort(function (a, b) {
-        return a.time - b.time;
+        return b.time - a.time;
       }).slice(0, 10);
       var _html = '<div class="bull-slide">';
       _html += '<div class="bull-title">Top Touro 🐂</div>';

--- a/src/js/mobile.js
+++ b/src/js/mobile.js
@@ -34,7 +34,7 @@ function render(){
   container.innerHTML='';
   if(state.bullTimes.length>0){
     const keys=['bullFirst','bullSecond','bullThird','bullFourth','bullFifth'];
-    const sorted=[...state.bullTimes].sort((a,b)=>a.time-b.time).slice(0,5);
+    const sorted=[...state.bullTimes].sort((a,b)=>b.time-a.time).slice(0,5);
     const card=document.createElement('div');
     card.className='card bull-card';
     let html='<h2>Top Touro 🐂</h2><ol>';

--- a/src/js/slides.js
+++ b/src/js/slides.js
@@ -46,7 +46,7 @@ function render(){
   const slides=[];
     if(state.bullTimes.length>0){
       const keys=['bullFirst','bullSecond','bullThird','bullFourth','bullFifth'];
-      const sorted=[...state.bullTimes].sort((a,b)=>a.time-b.time).slice(0,10);
+      const sorted=[...state.bullTimes].sort((a,b)=>b.time-a.time).slice(0,10);
       let html='<div class="bull-slide">';
       html+='<div class="bull-title">Top Touro 🐂</div>';
       html+='<table class="bull-table">';

--- a/src/server.js
+++ b/src/server.js
@@ -74,7 +74,7 @@ function computeScores() {
   data.scores = {blue:0, yellow:0};
   if (data.bullFinished && data.bullTimes.length > 0) {
     const keys = ['bullFirst','bullSecond','bullThird','bullFourth','bullFifth'];
-    const sorted = [...data.bullTimes].sort((a,b)=>a.time-b.time).slice(0, keys.length);
+    const sorted = [...data.bullTimes].sort((a,b)=>b.time-a.time).slice(0, keys.length);
     sorted.forEach((r,i)=>{
       const k = keys[i];
       const team = data.players[r.name];


### PR DESCRIPTION
## Summary
- sort bull times descending when rendering slides and mobile view
- compute scores using descending order
- rebuild compiled JS

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684cf10e1338833195e5983509d4e410