### PR TITLE
Improve mobile view layout and history

### DIFF
--- a/public/js/mobile.js
+++ b/public/js/mobile.js
@@ -22,27 +22,67 @@ if (!document.querySelector) {
 } else {
   var render = function render() {
     container.innerHTML = '';
+    attractionsEl.innerHTML = '';
+    if (state.attractions.length > 0) {
+      var now = new Date();
+      var attractions = _toConsumableArray(state.attractions).sort(function (a, b) {
+        return new Date(a.time) - new Date(b.time);
+      });
+      var current = attractions.filter(function (a) {
+        return new Date(a.time) <= now;
+      }).pop();
+      var next = attractions.find(function (a) {
+        return new Date(a.time) > now;
+      });
+      var html = '';
+      if (current) {
+        html += "<div class=\"attractions-label\">Agora:</div><div class=\"attractions-current\">".concat(current.name, "</div>");
+      }
+      if (next) {
+        var diff = Math.ceil((new Date(next.time) - now) / 60000);
+        html += "<div class=\"attractions-label\">Em seguida:</div><div class=\"attractions-next\">".concat(next.name, " <span class=\"clock\">\uD83D\uDD52 ").concat(diff, " min</span></div>");
+      }
+      attractionsEl.innerHTML = html;
+    }
+    var scoreEntries = Object.entries(state.scores).sort(function (a, b) {
+      return b[1] - a[1];
+    });
+    var maxScore = Math.max.apply(Math, _toConsumableArray(scoreEntries.map(function (s) {
+      return s[1];
+    })).concat([1]));
+    var scoreCard = document.createElement('div');
+    scoreCard.className = 'card score-card';
+    var scoreHtml = '<h2>Placar 🏆</h2>';
+    scoreEntries.forEach(function (_ref, i) {
+      var _ref2 = _slicedToArray(_ref, 2),
+        team = _ref2[0],
+        score = _ref2[1];
+      var pct = Math.round(score / maxScore * 100);
+      scoreHtml += "<div class=\"score-row\"><div class=\"score-bar team-".concat(team, "\" style=\"width:").concat(pct, "%\">").concat(state.teamNames[team], " - ").concat(score).concat(i == 0 ? ' 🏆' : '', "</div></div>");
+    });
+    scoreCard.innerHTML = scoreHtml;
+    container.appendChild(scoreCard);
     if (state.bullTimes.length > 0) {
       var keys = ['bullFirst', 'bullSecond', 'bullThird', 'bullFourth', 'bullFifth'];
       var sorted = _toConsumableArray(state.bullTimes).sort(function (a, b) {
         return b.time - a.time;
-      }).slice(0, 5);
-      var _card = document.createElement('div');
-      _card.className = 'card bull-card';
+      });
+      var card = document.createElement('div');
+      card.className = 'card bull-card';
       var _html = '<h2>Touro Mecânico 🐂</h2><ol>';
       sorted.forEach(function (r, i) {
         var pts = i < keys.length ? state.points[keys[i]] || 0 : 0;
         _html += "<li><span class=\"team-".concat(state.players[r.name], "\">").concat(r.name, "</span> - ").concat(r.time, "s (").concat(pts, " pts)").concat(i == 0 ? ' 🏆' : '', "</li>");
       });
       _html += '</ol>';
-      _card.innerHTML = _html;
-      container.appendChild(_card);
+      card.innerHTML = _html;
+      container.appendChild(card);
     }
     if (state.cottonWars.length > 0) {
       var pts = state.points.cottonWin || 0;
       var recent = state.cottonWars.slice().reverse();
-      var _card2 = document.createElement('div');
-      _card2.className = 'card cotton-card';
+      var _card = document.createElement('div');
+      _card.className = 'card cotton-card';
       var _html2 = '<h2>Guerra de Cotonete ⚔️</h2>';
       _html2 += '<ul>';
       recent.forEach(function (b) {
@@ -55,12 +95,12 @@ if (!document.querySelector) {
         _html2 += "<li><span class=\"team-".concat(state.players[b.p1], "\">").concat(b.p1).concat(trophy1, "</span> vs <span class=\"team-").concat(state.players[b.p2], "\">").concat(b.p2).concat(trophy2, "</span> (+").concat(pts, ") <small>").concat(time, "</small></li>");
       });
       _html2 += '</ul>';
-      _card2.innerHTML = _html2;
-      container.appendChild(_card2);
+      _card.innerHTML = _html2;
+      container.appendChild(_card);
     }
     if (state.bingoWinners) {
-      var _card3 = document.createElement('div');
-      _card3.className = 'card bingo-card';
+      var _card2 = document.createElement('div');
+      _card2.className = 'card bingo-card';
       var _html3 = '<h2>Bingo 🎉</h2><ol>';
       var rows = [{
         name: state.bingoWinners.first,
@@ -81,14 +121,14 @@ if (!document.querySelector) {
         _html3 += "<li>".concat(r.pos, " <span class=\"team-").concat(state.players[r.name], "\">").concat(r.name || '', "</span> (").concat(pts, " pts) ").concat(r.trophy || '', "</li>");
       });
       _html3 += '</ol>';
-      _card3.innerHTML = _html3;
-      container.appendChild(_card3);
+      _card2.innerHTML = _html3;
+      container.appendChild(_card2);
     }
     if (state.beerPongs.length > 0) {
       var _pts = state.points.beerWin || 0;
       var _recent = state.beerPongs.slice().reverse();
-      var _card4 = document.createElement('div');
-      _card4.className = 'card beer-card';
+      var _card3 = document.createElement('div');
+      _card3.className = 'card beer-card';
       var _html4 = '<h2>🍺 Beer Pong 🍺</h2><ul>';
       _recent.forEach(function (b) {
         var team1Color = state.players[b.team1[0]];
@@ -98,14 +138,14 @@ if (!document.querySelector) {
         _html4 += "<li><span class=\"team-".concat(team1Color, "\">").concat(b.team1[0], "</span> & <span class=\"team-").concat(team1Color, "\">").concat(b.team1[1], "</span>").concat(trophy1, " vs <span class=\"team-").concat(team2Color, "\">").concat(b.team2[0], "</span> & <span class=\"team-").concat(team2Color, "\">").concat(b.team2[1], "</span>").concat(trophy2, " (+").concat(_pts, ")</li>");
       });
       _html4 += '</ul>';
-      _card4.innerHTML = _html4;
-      container.appendChild(_card4);
+      _card3.innerHTML = _html4;
+      container.appendChild(_card3);
     }
     if (state.pacalWars.length > 0) {
       var _pts2 = state.points.pacalWin || 0;
       var _recent2 = state.pacalWars.slice().reverse();
-      var _card5 = document.createElement('div');
-      _card5.className = 'card pacal-card';
+      var _card4 = document.createElement('div');
+      _card4.className = 'card pacal-card';
       var _html5 = '<h2>Pacal 🎯</h2><ul>';
       _recent2.forEach(function (b) {
         var trophy1 = b.winner === b.p1 ? '🏆' : '';
@@ -113,51 +153,9 @@ if (!document.querySelector) {
         _html5 += "<li><span class=\"team-".concat(state.players[b.p1], "\">").concat(b.p1).concat(trophy1, "</span> vs <span class=\"team-").concat(state.players[b.p2], "\">").concat(b.p2).concat(trophy2, "</span> (+").concat(_pts2, ")</li>");
       });
       _html5 += '</ul>';
-      _card5.innerHTML = _html5;
-      container.appendChild(_card5);
+      _card4.innerHTML = _html5;
+      container.appendChild(_card4);
     }
-    if (state.attractions.length > 0) {
-      var now = new Date();
-      var attractions = _toConsumableArray(state.attractions).sort(function (a, b) {
-        return new Date(a.time) - new Date(b.time);
-      });
-      var current = attractions.filter(function (a) {
-        return new Date(a.time) <= now;
-      }).pop();
-      var next = attractions.find(function (a) {
-        return new Date(a.time) > now;
-      });
-      var _card6 = document.createElement('div');
-      _card6.className = 'card attractions-card';
-      var _html6 = '<h2>Atrações 🎡</h2>';
-      if (current) {
-        _html6 += "<div>Agora: <strong>".concat(current.name, "</strong></div>");
-      }
-      if (next) {
-        var diff = Math.ceil((new Date(next.time) - now) / 60000);
-        _html6 += "<div>Em seguida: ".concat(next.name, " <span class=\"clock\">\uD83D\uDD52 ").concat(diff, " min</span></div>");
-      }
-      _card6.innerHTML = _html6;
-      container.appendChild(_card6);
-    }
-    var scoreEntries = Object.entries(state.scores).sort(function (a, b) {
-      return b[1] - a[1];
-    });
-    var maxScore = Math.max.apply(Math, _toConsumableArray(scoreEntries.map(function (s) {
-      return s[1];
-    })).concat([1]));
-    var card = document.createElement('div');
-    card.className = 'card score-card';
-    var html = '<h2>Placar 🏆</h2>';
-    scoreEntries.forEach(function (_ref, i) {
-      var _ref2 = _slicedToArray(_ref, 2),
-        team = _ref2[0],
-        score = _ref2[1];
-      var pct = Math.round(score / maxScore * 100);
-      html += "<div class=\"score-row\"><div class=\"score-bar team-".concat(team, "\" style=\"width:").concat(pct, "%\">").concat(state.teamNames[team], " - ").concat(score).concat(i == 0 ? ' 🏆' : '', "</div></div>");
-    });
-    card.innerHTML = html;
-    container.appendChild(card);
   };
   var _updateAndRender = function updateAndRender(data) {
     try {
@@ -187,6 +185,7 @@ if (!document.querySelector) {
     pollTimer = setInterval(fetchState, 5000);
   };
   var container = document.getElementById('cards');
+  var attractionsEl = document.getElementById('attractions-info');
   var defaultState = {
     players: {},
     bullTimes: [],

--- a/public/mobile/index.html
+++ b/public/mobile/index.html
@@ -7,6 +7,10 @@
 <style>
 body{margin:0;padding:0;font-family:sans-serif;background:black;color:white;}
 .header-img{display:block;margin:10px auto;max-width:200px;width:80%;}
+#attractions-info{text-align:center;font-weight:bold;margin:10px 0;}
+.attractions-label{font-size:1.2em;}
+.attractions-current{font-size:2em;font-weight:bold;margin-bottom:5px;}
+.attractions-next{font-size:1.5em;}
 .card{border-radius:8px;margin:10px;padding:10px;color:white;}
 .bull-card{background:#330000;}
 .cotton-card{background:#002b00;}
@@ -25,6 +29,7 @@ body{margin:0;padding:0;font-family:sans-serif;background:black;color:white;}
 </head>
 <body>
 <img src="../images/admin-header.png" alt="Logo" class="header-img">
+<div id="attractions-info"></div>
 <div id="cards"></div>
 <script src="../js/mobile.js"></script>
 </body>

--- a/src/js/mobile.js
+++ b/src/js/mobile.js
@@ -3,6 +3,7 @@ if(!document.querySelector){
   console.warn('Navegador sem suporte: querySelector ausente');
 }else{
 const container=document.getElementById('cards');
+const attractionsEl=document.getElementById('attractions-info');
 const defaultState={
   players:{},
   bullTimes:[],
@@ -32,9 +33,37 @@ let state={...defaultState};
 let pollTimer;
 function render(){
   container.innerHTML='';
+  attractionsEl.innerHTML='';
+  if(state.attractions.length>0){
+    const now=new Date();
+    const attractions=[...state.attractions].sort((a,b)=>new Date(a.time)-new Date(b.time));
+    const current=attractions.filter(a=>new Date(a.time)<=now).pop();
+    const next=attractions.find(a=> new Date(a.time)>now);
+    let html='';
+    if(current){
+      html+=`<div class="attractions-label">Agora:</div><div class="attractions-current">${current.name}</div>`;
+    }
+    if(next){
+      const diff=Math.ceil((new Date(next.time)-now)/60000);
+      html+=`<div class="attractions-label">Em seguida:</div><div class="attractions-next">${next.name} <span class="clock">🕒 ${diff} min</span></div>`;
+    }
+    attractionsEl.innerHTML=html;
+  }
+
+  const scoreEntries=Object.entries(state.scores).sort((a,b)=>b[1]-a[1]);
+  const maxScore=Math.max(...scoreEntries.map(s=>s[1]),1);
+  const scoreCard=document.createElement('div');
+  scoreCard.className='card score-card';
+  let scoreHtml='<h2>Placar 🏆</h2>';
+  scoreEntries.forEach(([team,score],i)=>{
+    const pct=Math.round(score/maxScore*100);
+    scoreHtml+=`<div class="score-row"><div class="score-bar team-${team}" style="width:${pct}%">${state.teamNames[team]} - ${score}${i==0?' 🏆':''}</div></div>`;
+  });
+  scoreCard.innerHTML=scoreHtml;
+  container.appendChild(scoreCard);
   if(state.bullTimes.length>0){
     const keys=['bullFirst','bullSecond','bullThird','bullFourth','bullFifth'];
-    const sorted=[...state.bullTimes].sort((a,b)=>b.time-a.time).slice(0,5);
+    const sorted=[...state.bullTimes].sort((a,b)=>b.time-a.time);
     const card=document.createElement('div');
     card.className='card bull-card';
     let html='<h2>Touro Mecânico 🐂</h2><ol>';
@@ -112,35 +141,6 @@ function render(){
     card.innerHTML=html;
     container.appendChild(card);
   }
-  if(state.attractions.length>0){
-    const now=new Date();
-    const attractions=[...state.attractions].sort((a,b)=>new Date(a.time)-new Date(b.time));
-    const current=attractions.filter(a=>new Date(a.time)<=now).pop();
-    const next=attractions.find(a=> new Date(a.time)>now);
-    const card=document.createElement('div');
-    card.className='card attractions-card';
-    let html='<h2>Atrações 🎡</h2>';
-    if(current){
-      html+=`<div>Agora: <strong>${current.name}</strong></div>`;
-    }
-    if(next){
-      const diff=Math.ceil((new Date(next.time)-now)/60000);
-      html+=`<div>Em seguida: ${next.name} <span class="clock">🕒 ${diff} min</span></div>`;
-    }
-    card.innerHTML=html;
-    container.appendChild(card);
-  }
-  const scoreEntries=Object.entries(state.scores).sort((a,b)=>b[1]-a[1]);
-  const maxScore=Math.max(...scoreEntries.map(s=>s[1]),1);
-  const card=document.createElement('div');
-  card.className='card score-card';
-  let html='<h2>Placar 🏆</h2>';
-  scoreEntries.forEach(([team,score],i)=>{
-    const pct=Math.round(score/maxScore*100);
-    html+=`<div class="score-row"><div class="score-bar team-${team}" style="width:${pct}%">${state.teamNames[team]} - ${score}${i==0?' 🏆':''}</div></div>`;
-  });
-  card.innerHTML=html;
-  container.appendChild(card);
 }
 function updateAndRender(data){
   try{


### PR DESCRIPTION
## Summary
- reorder scoreboard to be the first card on mobile
- show the full history for bull riding
- display attractions info below the logo, outside of cards

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684cf3981e708331bea5694aeec3de21