### PR TITLE
Add iOS home screen invite on mobile

### DIFF
--- a/public/mobile/index.html
+++ b/public/mobile/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="apple-touch-icon" href="../appicon.jpg">
 <title>Arraiá do Lowis 3</title>
 <style>
 body{margin:0;padding:0;font-family:sans-serif;background:black;color:white;}
@@ -25,10 +26,16 @@ body{margin:0;padding:0;font-family:sans-serif;background:black;color:white;}
 .score-bar{background:rgba(255,255,255,0.2);border-radius:4px;padding:4px;}
 .score-bar.team-blue{background-color:#1c3c7d;}
 .score-bar.team-yellow{background-color:#7d6a1c;color:black;}
+.install-card{background:#000033;text-align:center;display:flex;align-items:center;gap:10px;}
+.install-card img{width:60px;height:60px;border-radius:12px;}
 </style>
 </head>
 <body>
 <img src="../images/admin-header.png" alt="Logo" class="header-img">
+<div class="card install-card">
+  <img src="../appicon.jpg" alt="Ícone do app">
+  <div>Adicione este site à tela inicial: toque em <strong>Compartilhar</strong> e depois <strong>Adicionar à Tela de Início</strong>.</div>
+</div>
 <div id="attractions-info"></div>
 <div id="cards"></div>
 <script src="../js/mobile.js"></script>


### PR DESCRIPTION
## Summary
- show an installation prompt on /mobile
- reference appicon for iOS home screen

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d09b0ded883319eb0989f5b21eecd