### PR TITLE
Add iOS status bar meta tags to mobile page

### DIFF
--- a/public/mobile/index.html
+++ b/public/mobile/index.html
@@ -3,6 +3,8 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <link rel="apple-touch-icon" href="../appicon.jpg">
 <title>Arraiá do Lowis 3</title>
 <style>


### PR DESCRIPTION
## Summary
- update `/mobile` index to include iOS web-app status bar meta tags

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d113e1f64833180f556b157ca5eac