### PR TITLE
Add iOS install prompt to admin page

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -3,6 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<link rel="apple-touch-icon" href="adminicon.png">
 <title>Admin Arraia</title>
 <style>
 body{
@@ -36,6 +39,9 @@ body{
 }
 .menu-item span.emoji{font-size:48px;}
 .menu-item span.label{margin-top:auto;padding-bottom:5px;font-size:14px;}
+ .install-prompt{text-align:center;margin:20px 0;}
+ .install-prompt img{width:60px;height:60px;border-radius:12px;display:block;margin:0 auto;}
+ .install-hint{font-size:0.8em;}
 @media(max-width:600px){
   body{grid-template-columns:repeat(2,1fr);}
 }
@@ -83,5 +89,10 @@ body{
   <span class="emoji">♻️</span>
   <span class="label">Reset</span>
 </a>
+<div class="install-prompt">
+  <img src="adminicon.png" alt="Ícone do app">
+  <strong>Instalar app</strong><br>
+  <span class="install-hint">Toque em compartilhar e add à tela de início</span>
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show iOS add-to-home-screen instructions on admin page
- use `adminicon.png` as the Apple touch icon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d136b40b08331a9cd26ca11defb48