### PR TITLE
Serve mobile page at root

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ automatically during the build.
 docker run -p 3000:3000 -v /path/on/host:/app/data arraia
 ```
 
-Then access `http://localhost:3000/` for slides,
+Then access `http://localhost:3000/tv` for slides,
+`http://localhost:3000/` for the mobile view,
 `http://localhost:3000/admin.html` for the admin menu,
 `http://localhost:3000/players.html` to manage players,
 `http://localhost:3000/teams.html` to edit team names,

--- a/public/index.html
+++ b/public/index.html
@@ -66,6 +66,6 @@ body,html{margin:0;padding:0;height:100%;width:100%;font-family:'Trebuchet MS',s
 </head>
 <body>
 <div id="slides"></div>
-<script src="js/slides.js"></script>
+<script src="/js/slides.js"></script>
 </body>
 </html>

--- a/src/server.js
+++ b/src/server.js
@@ -7,6 +7,17 @@ const app = express();
 const port = process.env.PORT || 3000;
 
 app.use(bodyParser.json());
+
+// Serve mobile view at root
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, '..', 'public', 'mobile', 'index.html'));
+});
+
+// Serve slideshow view under /tv
+app.get('/tv', (req, res) => {
+  res.sendFile(path.join(__dirname, '..', 'public', 'index.html'));
+});
+
 app.use(express.static(path.join(__dirname, '..', 'public')));
 
 const DATA_FILE = process.env.DATA_FILE || path.join(process.env.DATA_DIR || path.join(__dirname, '..', 'data'), 'data.json');


### PR DESCRIPTION
## Summary
- show the mobile interface on `/`
- move the slideshow to `/tv`
- load slides script from an absolute path
- update README with new URLs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684da42fdf34833187a43adccf762aaf