### PR TITLE
Implement game visibility controls

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -85,6 +85,10 @@ body{
   <span class="emoji">🏅</span>
   <span class="label">Pontos</span>
 </a>
+<a class="menu-item" href="games.html">
+  <span class="emoji">🎮</span>
+  <span class="label">Jogos</span>
+</a>
 <a class="menu-item" href="reset.html">
   <span class="emoji">♻️</span>
   <span class="label">Reset</span>

--- a/public/games.html
+++ b/public/games.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Jogos</title>
+<style>
+body{font-family:'Trebuchet MS',sans-serif;padding:10px;max-width:480px;margin:auto;}
+label{display:block;margin-top:10px;}
+input[type=checkbox]{margin-right:10px;}
+button{margin-top:20px;padding:8px 12px;font-size:16px;}
+</style>
+</head>
+<body>
+<h1>Mostrar Jogos</h1>
+<div id="games"></div>
+<button onclick="save()">Salvar</button>
+<script>
+const games=[
+  {key:'bull',label:'Touro Mec\u00E2nico'},
+  {key:'cotton',label:'Cotonete'},
+  {key:'beer',label:'Beer Pong'},
+  {key:'pacal',label:'Pacal'},
+  {key:'bingo',label:'Bingo'}
+];
+function load(){
+  fetch('/api/hidden-games').then(r=>r.json()).then(h=>{
+    const container=document.getElementById('games');
+    container.innerHTML='';
+    games.forEach(g=>{
+      const div=document.createElement('label');
+      div.innerHTML=`<input type='checkbox' id='game-${g.key}'> ${g.label}`;
+      container.appendChild(div);
+      document.getElementById('game-'+g.key).checked=!h[g.key];
+    });
+  });
+}
+function save(){
+  const body={};
+  games.forEach(g=>{
+    body[g.key]=!document.getElementById('game-'+g.key).checked;
+  });
+  fetch('/api/hidden-games',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+}
+load();
+</script>
+</body>
+</html>

--- a/public/js/mobile.js
+++ b/public/js/mobile.js
@@ -62,7 +62,7 @@ if (!document.querySelector) {
     });
     scoreCard.innerHTML = scoreHtml;
     container.appendChild(scoreCard);
-    if (state.bullTimes.length > 0) {
+    if (state.bullTimes.length > 0 && !state.hiddenGames.bull) {
       var keys = ['bullFirst', 'bullSecond', 'bullThird', 'bullFourth', 'bullFifth'];
       var sorted = _toConsumableArray(state.bullTimes).sort(function (a, b) {
         return b.time - a.time;
@@ -78,7 +78,7 @@ if (!document.querySelector) {
       card.innerHTML = _html;
       container.appendChild(card);
     }
-    if (state.cottonWars.length > 0) {
+    if (state.cottonWars.length > 0 && !state.hiddenGames.cotton) {
       var pts = state.points.cottonWin || 0;
       var recent = state.cottonWars.slice().reverse();
       var _card = document.createElement('div');
@@ -98,7 +98,7 @@ if (!document.querySelector) {
       _card.innerHTML = _html2;
       container.appendChild(_card);
     }
-    if (state.bingoWinners) {
+    if (state.bingoWinners && !state.hiddenGames.bingo) {
       var _card2 = document.createElement('div');
       _card2.className = 'card bingo-card';
       var _html3 = '<h2>Bingo 🎉</h2><ol>';
@@ -126,7 +126,7 @@ if (!document.querySelector) {
       _card2.innerHTML = _html3;
       container.appendChild(_card2);
     }
-    if (state.beerPongs.length > 0) {
+    if (state.beerPongs.length > 0 && !state.hiddenGames.beer) {
       var _pts = state.points.beerWin || 0;
       var _recent = state.beerPongs.slice().reverse();
       var _card3 = document.createElement('div');
@@ -143,7 +143,7 @@ if (!document.querySelector) {
       _card3.innerHTML = _html4;
       container.appendChild(_card3);
     }
-    if (state.pacalWars.length > 0) {
+    if (state.pacalWars.length > 0 && !state.hiddenGames.pacal) {
       var _pts2 = state.points.pacalWin || 0;
       var _recent2 = state.pacalWars.slice(-6).reverse();
       var _card4 = document.createElement('div');
@@ -219,7 +219,8 @@ if (!document.querySelector) {
     scores: {
       blue: 0,
       yellow: 0
-    }
+    },
+    hiddenGames: {}
   };
   var state = _objectSpread({}, defaultState);
   var pollTimer;

--- a/public/js/slides.js
+++ b/public/js/slides.js
@@ -24,7 +24,7 @@ if (!document.querySelector) {
     clearTimeout(timer);
     slidesEl.innerHTML = '';
     var slides = [];
-    if (state.bullTimes.length > 0) {
+    if (state.bullTimes.length > 0 && !state.hiddenGames.bull) {
       var keys = ['bullFirst', 'bullSecond', 'bullThird', 'bullFourth', 'bullFifth'];
       var sorted = _toConsumableArray(state.bullTimes).sort(function (a, b) {
         return b.time - a.time;
@@ -57,7 +57,7 @@ if (!document.querySelector) {
         html: _html
       });
     }
-    if (state.cottonWars.length > 0) {
+    if (state.cottonWars.length > 0 && !state.hiddenGames.cotton) {
       var _pts = state.points.cottonWin || 0;
       var recent = state.cottonWars.slice().reverse();
       var _html2 = '<div class="cotton-slide"><h1>Guerra de Cotonete ⚔️</h1><div class="cotton-wrapper">';
@@ -77,7 +77,7 @@ if (!document.querySelector) {
         html: _html2
       });
     }
-    if (state.bingoWinners) {
+    if (state.bingoWinners && !state.hiddenGames.bingo) {
       var _html3 = '<div class="bingo-slide">';
       _html3 += '<div class="bingo-title">Bingo 🎉</div>';
       _html3 += '<table class="bingo-table">';
@@ -109,7 +109,7 @@ if (!document.querySelector) {
         html: _html3
       });
     }
-    if (state.beerPongs.length > 0) {
+    if (state.beerPongs.length > 0 && !state.hiddenGames.beer) {
       var _pts2 = state.points.beerWin || 0;
       var _recent = state.beerPongs.slice(-6).reverse();
       var _html4 = '<div class="beer-slide"><h1 class="beer-title">🍺 Beer Pong 🍺</h1><div class="beer-wrapper">';
@@ -127,7 +127,7 @@ if (!document.querySelector) {
         html: _html4
       });
     }
-    if (state.pacalWars.length > 0) {
+    if (state.pacalWars.length > 0 && !state.hiddenGames.pacal) {
       var _pts3 = state.points.pacalWin || 0;
       var _recent2 = state.pacalWars.slice(-6).reverse();
       var _html5 = '<div class="pacal-slide"><h1>Pacal 🎯</h1><div class="pacal-wrapper">';
@@ -294,7 +294,8 @@ if (!document.querySelector) {
     scores: {
       blue: 0,
       yellow: 0
-    }
+    },
+    hiddenGames: {}
   };
   var state = _objectSpread({}, defaultState);
   var timer;

--- a/src/js/mobile.js
+++ b/src/js/mobile.js
@@ -28,6 +28,7 @@ const defaultState={
     bingoThird:1
   },
   scores:{blue:0,yellow:0},
+  hiddenGames:{},
 };
 let state={...defaultState};
 let pollTimer;
@@ -61,7 +62,7 @@ function render(){
   });
   scoreCard.innerHTML=scoreHtml;
   container.appendChild(scoreCard);
-  if(state.bullTimes.length>0){
+  if(state.bullTimes.length>0 && !state.hiddenGames.bull){
     const keys=['bullFirst','bullSecond','bullThird','bullFourth','bullFifth'];
     const sorted=[...state.bullTimes].sort((a,b)=>b.time-a.time);
     const card=document.createElement('div');
@@ -75,7 +76,7 @@ function render(){
     card.innerHTML=html;
     container.appendChild(card);
   }
-  if(state.cottonWars.length>0){
+  if(state.cottonWars.length>0 && !state.hiddenGames.cotton){
     const pts=state.points.cottonWin||0;
     const recent=state.cottonWars.slice().reverse();
     const card=document.createElement('div');
@@ -92,7 +93,7 @@ function render(){
     card.innerHTML=html;
     container.appendChild(card);
   }
-  if(state.bingoWinners){
+  if(state.bingoWinners && !state.hiddenGames.bingo){
     const card=document.createElement('div');
     card.className='card bingo-card';
     let html='<h2>Bingo 🎉</h2><ol>';
@@ -109,7 +110,7 @@ function render(){
     card.innerHTML=html;
     container.appendChild(card);
   }
-  if(state.beerPongs.length>0){
+  if(state.beerPongs.length>0 && !state.hiddenGames.beer){
     const pts=state.points.beerWin||0;
     const recent=state.beerPongs.slice().reverse();
     const card=document.createElement('div');
@@ -126,7 +127,7 @@ function render(){
     card.innerHTML=html;
     container.appendChild(card);
   }
-  if(state.pacalWars.length>0){
+  if(state.pacalWars.length>0 && !state.hiddenGames.pacal){
     const pts=state.points.pacalWin||0;
     const recent=state.pacalWars.slice(-6).reverse();
     const card=document.createElement('div');

--- a/src/js/slides.js
+++ b/src/js/slides.js
@@ -26,7 +26,8 @@ const defaultState={
     bingoSecond:3,
     bingoThird:1
   },
-  scores:{blue:0,yellow:0}
+  scores:{blue:0,yellow:0},
+  hiddenGames:{}
 };
 let state={...defaultState};
 let timer;
@@ -44,7 +45,7 @@ function render(){
   clearTimeout(timer);
   slidesEl.innerHTML='';
   const slides=[];
-    if(state.bullTimes.length>0){
+    if(state.bullTimes.length>0 && !state.hiddenGames.bull){
       const keys=['bullFirst','bullSecond','bullThird','bullFourth','bullFifth'];
       const sorted=[...state.bullTimes].sort((a,b)=>b.time-a.time).slice(0,10);
       let html='<div class="bull-slide">';
@@ -67,7 +68,7 @@ function render(){
       html+='</table></div>';
       slides.push({color:'darkred',image:bgImages.bull,html});
     }
-  if(state.cottonWars.length>0){
+  if(state.cottonWars.length>0 && !state.hiddenGames.cotton){
     const pts = state.points.cottonWin || 0;
     const recent = state.cottonWars.slice().reverse();
     let html='<div class="cotton-slide"><h1>Guerra de Cotonete ⚔️</h1><div class="cotton-wrapper">';
@@ -80,7 +81,7 @@ function render(){
     html+='</div></div>';
     slides.push({color:'green',image:bgImages.cotton,html});
   }
-  if(state.bingoWinners){
+  if(state.bingoWinners && !state.hiddenGames.bingo){
     let html='<div class="bingo-slide">';
     html+='<div class="bingo-title">Bingo 🎉</div>';
     html+='<table class="bingo-table">';
@@ -97,7 +98,7 @@ function render(){
     html+='</table></div>';
     slides.push({color:'purple',image:bgImages.bingo,html});
   }
-  if(state.beerPongs.length>0){
+  if(state.beerPongs.length>0 && !state.hiddenGames.beer){
     const pts = state.points.beerWin || 0;
     const recent = state.beerPongs.slice(-6).reverse();
     let html='<div class="beer-slide"><h1 class="beer-title">🍺 Beer Pong 🍺</h1><div class="beer-wrapper">';
@@ -111,7 +112,7 @@ function render(){
     html+='</div></div>';
     slides.push({color:'orange',image:bgImages.beer,html});
   }
-  if(state.pacalWars.length>0){
+  if(state.pacalWars.length>0 && !state.hiddenGames.pacal){
     const pts = state.points.pacalWin || 0;
     const recent = state.pacalWars.slice(-6).reverse();
     let html='<div class="pacal-slide"><h1>Pacal 🎯</h1><div class="pacal-wrapper">';

--- a/src/server.js
+++ b/src/server.js
@@ -45,7 +45,8 @@ const defaultData = {
     bingoSecond: 3,
     bingoThird: 1
   },
-  scores: {blue:0, yellow:0}
+  scores: {blue:0, yellow:0},
+  hiddenGames: {}
 };
 
 let data = JSON.parse(JSON.stringify(defaultData));
@@ -378,9 +379,20 @@ app.post('/api/config/points', (req,res)=>{
   res.end();
 });
 
+app.get('/api/hidden-games', (req,res)=>{
+  res.json(data.hiddenGames);
+});
+
+app.post('/api/hidden-games', (req,res)=>{
+  if(typeof req.body!== 'object') return res.status(400).end();
+  data.hiddenGames = { ...data.hiddenGames, ...req.body };
+  saveData();
+  res.end();
+});
+
 app.post('/api/reset', (req,res)=>{
   Object.assign(data, {
-    players:{}, bullTimes:[], bullFinished:false, cottonWars:[], beerPongs:[], pacalWars:[], bingoWinners:null, attractions:[], scores:{blue:0,yellow:0}
+    players:{}, bullTimes:[], bullFinished:false, cottonWars:[], beerPongs:[], pacalWars:[], bingoWinners:null, attractions:[], scores:{blue:0,yellow:0}, hiddenGames:{}
   });
   saveData();
   res.end();

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -192,4 +192,22 @@ describe('Express API', () => {
 
     await request(app).put('/api/player/Other').send({ name: 'Existing' }).expect(409);
   });
+
+  it('updates hidden games configuration', async () => {
+    await request(app)
+      .post('/api/hidden-games')
+      .send({ beer: true })
+      .expect(200);
+
+    let res = await request(app).get('/api/state').expect(200);
+    expect(res.body.hiddenGames.beer).toBe(true);
+
+    await request(app)
+      .post('/api/hidden-games')
+      .send({ beer: false })
+      .expect(200);
+
+    res = await request(app).get('/api/state').expect(200);
+    expect(res.body.hiddenGames.beer).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- add hiddenGames storage and endpoints on the server
- reset command now resets hidden games
- adjust slides/mobile scripts to skip hidden games
- compile assets
- add new admin page to control visibility
- link new page in admin menu
- test hidden games API

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dba5c4248833182f893d8389fc18d